### PR TITLE
feat(cadence): add insight-digest responder

### DIFF
--- a/src/cadence/responders/insight-digest/accumulator.test.ts
+++ b/src/cadence/responders/insight-digest/accumulator.test.ts
@@ -1,0 +1,527 @@
+/**
+ * Accumulator tests — exhaustive coverage for JSONL storage and flush logic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createAccumulator } from "./accumulator.js";
+import type { DigestConfig, QueuedInsight } from "./types.js";
+
+const baseConfig: DigestConfig = {
+  minInsightsToFlush: 5,
+  maxHoursBetweenFlushes: 12,
+  quietHoursStart: "22:00",
+  quietHoursEnd: "08:00",
+  timezone: "America/New_York",
+  cooldownHours: 4,
+  storePath: "", // Set in beforeEach
+  checkIntervalMs: 1000,
+};
+
+function createTestInsight(id: string, queuedAt: number = Date.now()): QueuedInsight {
+  return {
+    id,
+    queuedAt,
+    sourceSignalId: `signal-${id}`,
+    sourcePath: `/vault/journal/${id}.md`,
+    topic: `Topic ${id}`,
+    pillar: "norse",
+    hook: `Hook for ${id}`,
+    excerpt: `Excerpt for ${id}`,
+    scores: { topicClarity: 0.8, publishReady: 0.7, novelty: 0.9 },
+    formats: ["thread", "post"],
+  };
+}
+
+let testDir: string;
+let testConfig: DigestConfig;
+
+beforeEach(async () => {
+  testDir = path.join(
+    os.tmpdir(),
+    `insight-digest-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await fs.mkdir(testDir, { recursive: true });
+  testConfig = { ...baseConfig, storePath: path.join(testDir, "queue.jsonl") };
+});
+
+afterEach(async () => {
+  try {
+    await fs.rm(testDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+});
+
+describe("Enqueue Operations", () => {
+  it("enqueues single insight", async () => {
+    const accumulator = createAccumulator(testConfig);
+    const insight = createTestInsight("1");
+
+    await accumulator.enqueue(insight);
+    const queue = await accumulator.getQueue();
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("1");
+  });
+
+  it("enqueues multiple insights", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1"));
+    await accumulator.enqueue(createTestInsight("2"));
+    await accumulator.enqueue(createTestInsight("3"));
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(3);
+  });
+
+  it("preserves all insight fields", async () => {
+    const accumulator = createAccumulator(testConfig);
+    const insight: QueuedInsight = {
+      id: "test-full",
+      queuedAt: 1700000000000,
+      sourceSignalId: "sig-123",
+      sourcePath: "/vault/test.md",
+      topic: "Full Topic",
+      pillar: "technical",
+      hook: "A great hook",
+      excerpt: "The full excerpt text",
+      scores: { topicClarity: 0.95, publishReady: 0.85, novelty: 0.75 },
+      formats: ["essay", "video"],
+    };
+
+    await accumulator.enqueue(insight);
+    const queue = await accumulator.getQueue();
+
+    expect(queue[0]).toEqual(insight);
+  });
+
+  it("sets queuedAt timestamp", async () => {
+    const accumulator = createAccumulator(testConfig);
+    const now = Date.now();
+    const insight = createTestInsight("1", now);
+
+    await accumulator.enqueue(insight);
+    const queue = await accumulator.getQueue();
+
+    expect(queue[0].queuedAt).toBe(now);
+  });
+
+  it("handles duplicate IDs (appends, not replaces)", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1", 1000));
+    await accumulator.enqueue(createTestInsight("1", 2000));
+
+    const queue = await accumulator.getQueue();
+    // Both entries are kept (JSONL append-only)
+    // But Map dedupes by ID, so we get the latest
+    expect(queue).toHaveLength(1);
+    expect(queue[0].queuedAt).toBe(2000);
+  });
+
+  it("handles insight without pillar", async () => {
+    const accumulator = createAccumulator(testConfig);
+    const insight = createTestInsight("1");
+    delete (insight as Partial<QueuedInsight>).pillar;
+
+    await accumulator.enqueue(insight);
+    const queue = await accumulator.getQueue();
+
+    expect(queue[0].pillar).toBeUndefined();
+  });
+});
+
+describe("Queue Retrieval", () => {
+  it("returns empty array for fresh queue", async () => {
+    const accumulator = createAccumulator(testConfig);
+    const queue = await accumulator.getQueue();
+    expect(queue).toEqual([]);
+  });
+
+  it("returns all queued insights in order", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1", 1000));
+    await accumulator.enqueue(createTestInsight("2", 2000));
+    await accumulator.enqueue(createTestInsight("3", 3000));
+
+    const queue = await accumulator.getQueue();
+    expect(queue.map((i) => i.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("preserves insertion order (FIFO)", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    // Enqueue in reverse timestamp order
+    await accumulator.enqueue(createTestInsight("3", 3000));
+    await accumulator.enqueue(createTestInsight("1", 1000));
+    await accumulator.enqueue(createTestInsight("2", 2000));
+
+    const queue = await accumulator.getQueue();
+    // Sorted by queuedAt
+    expect(queue.map((i) => i.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("handles corrupted JSONL lines gracefully", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    // Write valid insight
+    await accumulator.enqueue(createTestInsight("1"));
+
+    // Manually append corrupted line
+    await fs.appendFile(testConfig.storePath, "not valid json\n");
+    await fs.appendFile(testConfig.storePath, '{"partial": true\n');
+
+    // Write another valid insight
+    await accumulator.enqueue(createTestInsight("2"));
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(2);
+    expect(queue.map((i) => i.id)).toEqual(["1", "2"]);
+  });
+});
+
+describe("Settled Insights (Cooldown)", () => {
+  it("excludes insights newer than cooldownHours", async () => {
+    const config = { ...testConfig, cooldownHours: 4 };
+    const accumulator = createAccumulator(config);
+    const now = Date.now();
+
+    // 1 hour ago (not settled)
+    await accumulator.enqueue(createTestInsight("1", now - 1 * 60 * 60 * 1000));
+
+    const settled = await accumulator.getSettledInsights();
+    expect(settled).toHaveLength(0);
+  });
+
+  it("includes insights older than cooldownHours", async () => {
+    const config = { ...testConfig, cooldownHours: 4 };
+    const accumulator = createAccumulator(config);
+    const now = Date.now();
+
+    // 5 hours ago (settled)
+    await accumulator.enqueue(createTestInsight("1", now - 5 * 60 * 60 * 1000));
+
+    const settled = await accumulator.getSettledInsights();
+    expect(settled).toHaveLength(1);
+  });
+
+  it("handles exactly-at-boundary timing", async () => {
+    const config = { ...testConfig, cooldownHours: 4 };
+    const accumulator = createAccumulator(config);
+    const now = Date.now();
+
+    // Exactly 4 hours ago (just settled)
+    await accumulator.enqueue(createTestInsight("1", now - 4 * 60 * 60 * 1000));
+
+    const settled = await accumulator.getSettledInsights();
+    expect(settled).toHaveLength(1);
+  });
+
+  it("returns empty if all insights are fresh", async () => {
+    const config = { ...testConfig, cooldownHours: 4 };
+    const accumulator = createAccumulator(config);
+    const now = Date.now();
+
+    await accumulator.enqueue(createTestInsight("1", now - 1 * 60 * 60 * 1000));
+    await accumulator.enqueue(createTestInsight("2", now - 2 * 60 * 60 * 1000));
+    await accumulator.enqueue(createTestInsight("3", now - 3 * 60 * 60 * 1000));
+
+    const settled = await accumulator.getSettledInsights();
+    expect(settled).toHaveLength(0);
+  });
+
+  it("returns all if all insights are settled", async () => {
+    const config = { ...testConfig, cooldownHours: 4 };
+    const accumulator = createAccumulator(config);
+    const now = Date.now();
+
+    await accumulator.enqueue(createTestInsight("1", now - 5 * 60 * 60 * 1000));
+    await accumulator.enqueue(createTestInsight("2", now - 6 * 60 * 60 * 1000));
+    await accumulator.enqueue(createTestInsight("3", now - 7 * 60 * 60 * 1000));
+
+    const settled = await accumulator.getSettledInsights();
+    expect(settled).toHaveLength(3);
+  });
+
+  it("mixed fresh/settled returns only settled", async () => {
+    const config = { ...testConfig, cooldownHours: 4 };
+    const accumulator = createAccumulator(config);
+    const now = Date.now();
+
+    await accumulator.enqueue(createTestInsight("fresh1", now - 1 * 60 * 60 * 1000));
+    await accumulator.enqueue(createTestInsight("settled1", now - 5 * 60 * 60 * 1000));
+    await accumulator.enqueue(createTestInsight("fresh2", now - 2 * 60 * 60 * 1000));
+    await accumulator.enqueue(createTestInsight("settled2", now - 6 * 60 * 60 * 1000));
+
+    const settled = await accumulator.getSettledInsights();
+    expect(settled).toHaveLength(2);
+    expect(settled.map((i) => i.id).sort()).toEqual(["settled1", "settled2"]);
+  });
+});
+
+describe("Dequeue Operations", () => {
+  it("removes specified IDs", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1"));
+    await accumulator.enqueue(createTestInsight("2"));
+    await accumulator.enqueue(createTestInsight("3"));
+
+    await accumulator.dequeue(["2"]);
+
+    const queue = await accumulator.getQueue();
+    expect(queue.map((i) => i.id)).toEqual(["1", "3"]);
+  });
+
+  it("preserves unspecified IDs", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1"));
+    await accumulator.enqueue(createTestInsight("2"));
+    await accumulator.enqueue(createTestInsight("3"));
+
+    await accumulator.dequeue(["1", "3"]);
+
+    const queue = await accumulator.getQueue();
+    expect(queue.map((i) => i.id)).toEqual(["2"]);
+  });
+
+  it("handles non-existent IDs gracefully", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1"));
+
+    await accumulator.dequeue(["nonexistent"]);
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(1);
+  });
+
+  it("handles empty ID array", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1"));
+
+    await accumulator.dequeue([]);
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(1);
+  });
+
+  it("handles dequeue of entire queue", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1"));
+    await accumulator.enqueue(createTestInsight("2"));
+    await accumulator.enqueue(createTestInsight("3"));
+
+    await accumulator.dequeue(["1", "2", "3"]);
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(0);
+  });
+});
+
+describe("Flush Conditions", () => {
+  it("returns false when under minInsightsToFlush", () => {
+    const config = { ...testConfig, minInsightsToFlush: 5 };
+    const accumulator = createAccumulator(config);
+
+    const settled = [createTestInsight("1"), createTestInsight("2")];
+    const result = accumulator.shouldFlush(settled);
+
+    expect(result.should).toBe(false);
+    expect(result.trigger).toBeNull();
+  });
+
+  it("returns true with trigger=count when at minInsightsToFlush", async () => {
+    const config = { ...testConfig, minInsightsToFlush: 3 };
+    const accumulator = createAccumulator(config);
+
+    // Need to call getQueue to populate cache
+    await accumulator.getQueue();
+
+    const settled = [createTestInsight("1"), createTestInsight("2"), createTestInsight("3")];
+    const result = accumulator.shouldFlush(settled);
+
+    expect(result.should).toBe(true);
+    expect(result.trigger).toBe("count");
+  });
+
+  it("returns true with trigger=count when over minInsightsToFlush", async () => {
+    const config = { ...testConfig, minInsightsToFlush: 2 };
+    const accumulator = createAccumulator(config);
+
+    await accumulator.getQueue();
+
+    const settled = [
+      createTestInsight("1"),
+      createTestInsight("2"),
+      createTestInsight("3"),
+      createTestInsight("4"),
+    ];
+    const result = accumulator.shouldFlush(settled);
+
+    expect(result.should).toBe(true);
+    expect(result.trigger).toBe("count");
+  });
+
+  it("returns true with trigger=time when maxHours exceeded (even if under count)", async () => {
+    const config = { ...testConfig, minInsightsToFlush: 10, maxHoursBetweenFlushes: 1 };
+    const accumulator = createAccumulator(config);
+
+    // Record a flush from 2 hours ago
+    await fs.mkdir(path.dirname(testConfig.storePath), { recursive: true });
+    const oldFlush = { type: "flush", at: Date.now() - 2 * 60 * 60 * 1000 };
+    await fs.writeFile(testConfig.storePath, JSON.stringify(oldFlush) + "\n");
+
+    await accumulator.getQueue(); // Populate cache
+
+    const settled = [createTestInsight("1")]; // Under minInsightsToFlush
+    const result = accumulator.shouldFlush(settled);
+
+    expect(result.should).toBe(true);
+    expect(result.trigger).toBe("time");
+  });
+
+  it("returns trigger=count when both conditions met (count takes priority)", async () => {
+    const config = { ...testConfig, minInsightsToFlush: 2, maxHoursBetweenFlushes: 1 };
+    const accumulator = createAccumulator(config);
+
+    // Record a flush from 2 hours ago
+    await fs.mkdir(path.dirname(testConfig.storePath), { recursive: true });
+    const oldFlush = { type: "flush", at: Date.now() - 2 * 60 * 60 * 1000 };
+    await fs.writeFile(testConfig.storePath, JSON.stringify(oldFlush) + "\n");
+
+    await accumulator.getQueue();
+
+    const settled = [createTestInsight("1"), createTestInsight("2"), createTestInsight("3")];
+    const result = accumulator.shouldFlush(settled);
+
+    expect(result.should).toBe(true);
+    expect(result.trigger).toBe("count");
+  });
+
+  it("tracks lastFlushAt correctly", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    const before = await accumulator.getLastFlushAt();
+    expect(before).toBe(0);
+
+    await accumulator.recordFlush();
+
+    const after = await accumulator.getLastFlushAt();
+    expect(after).toBeGreaterThan(0);
+    expect(after).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("resets lastFlushAt after flush", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    const t1 = Date.now();
+    await accumulator.recordFlush();
+    const first = await accumulator.getLastFlushAt();
+
+    // Wait a bit
+    await new Promise((r) => setTimeout(r, 10));
+
+    await accumulator.recordFlush();
+    const second = await accumulator.getLastFlushAt();
+
+    expect(second).toBeGreaterThan(first);
+    expect(second).toBeGreaterThan(t1);
+  });
+});
+
+describe("Edge Cases", () => {
+  it("handles missing storage file (creates fresh)", async () => {
+    const config = { ...testConfig, storePath: path.join(testDir, "new", "subdir", "queue.jsonl") };
+    const accumulator = createAccumulator(config);
+
+    // Should not throw
+    const queue = await accumulator.getQueue();
+    expect(queue).toEqual([]);
+
+    // Should create directory structure on enqueue
+    await accumulator.enqueue(createTestInsight("1"));
+    const queue2 = await accumulator.getQueue();
+    expect(queue2).toHaveLength(1);
+  });
+
+  it("handles empty storage file", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await fs.mkdir(path.dirname(testConfig.storePath), { recursive: true });
+    await fs.writeFile(testConfig.storePath, "");
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toEqual([]);
+  });
+
+  it("handles storage file with only whitespace", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await fs.mkdir(path.dirname(testConfig.storePath), { recursive: true });
+    await fs.writeFile(testConfig.storePath, "  \n\n  \n");
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toEqual([]);
+  });
+
+  it("handles very large queue (100+ insights)", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    for (let i = 0; i < 100; i++) {
+      await accumulator.enqueue(createTestInsight(`${i}`, i * 1000));
+    }
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(100);
+    expect(queue[0].id).toBe("0");
+    expect(queue[99].id).toBe("99");
+  });
+
+  it("handles unicode in insight content", async () => {
+    const accumulator = createAccumulator(testConfig);
+    const insight = createTestInsight("unicode");
+    insight.topic = "日本語トピック";
+    insight.hook = "北欧神話について 🌲";
+    insight.excerpt = "これは日本語のコンテンツです。絵文字: 🎉🚀";
+
+    await accumulator.enqueue(insight);
+    const queue = await accumulator.getQueue();
+
+    expect(queue[0].topic).toBe("日本語トピック");
+    expect(queue[0].hook).toBe("北欧神話について 🌲");
+  });
+
+  it("clear() removes all entries", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.enqueue(createTestInsight("1"));
+    await accumulator.enqueue(createTestInsight("2"));
+    await accumulator.enqueue(createTestInsight("3"));
+
+    await accumulator.clear();
+
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(0);
+  });
+
+  it("clear() resets lastFlushAt", async () => {
+    const accumulator = createAccumulator(testConfig);
+
+    await accumulator.recordFlush();
+    const before = await accumulator.getLastFlushAt();
+    expect(before).toBeGreaterThan(0);
+
+    await accumulator.clear();
+    const after = await accumulator.getLastFlushAt();
+    expect(after).toBe(0);
+  });
+});

--- a/src/cadence/responders/insight-digest/accumulator.ts
+++ b/src/cadence/responders/insight-digest/accumulator.ts
@@ -1,0 +1,207 @@
+/**
+ * Digest accumulator — JSONL storage and flush logic.
+ *
+ * Follows storage patterns from src/cron/run-log.ts.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { DigestConfig, QueuedInsight, FlushDecision, QueueState } from "./types.js";
+
+const log = createSubsystemLogger("cadence").child("digest-accumulator");
+
+/**
+ * JSONL line types for the queue file.
+ */
+type QueueLine =
+  | { type: "insight"; data: QueuedInsight }
+  | { type: "dequeue"; ids: string[] }
+  | { type: "flush"; at: number }
+  | { type: "clear" };
+
+export interface DigestAccumulator {
+  /** Add insight to queue */
+  enqueue(insight: QueuedInsight): Promise<void>;
+
+  /** Get all queued insights */
+  getQueue(): Promise<QueuedInsight[]>;
+
+  /** Get only "settled" insights (older than cooldownHours) */
+  getSettledInsights(): Promise<QueuedInsight[]>;
+
+  /** Remove flushed insights from queue */
+  dequeue(ids: string[]): Promise<void>;
+
+  /** Check if flush conditions met */
+  shouldFlush(settled: QueuedInsight[]): FlushDecision;
+
+  /** Record that a flush occurred */
+  recordFlush(): Promise<void>;
+
+  /** Get last flush timestamp */
+  getLastFlushAt(): Promise<number>;
+
+  /** Clear entire queue (for testing) */
+  clear(): Promise<void>;
+}
+
+/**
+ * Parse JSONL file into queue state.
+ */
+async function parseQueueFile(filePath: string): Promise<QueueState> {
+  const state: QueueState = {
+    lastFlushAt: 0,
+    insights: [],
+  };
+
+  const insightMap = new Map<string, QueuedInsight>();
+  const dequeuedIds = new Set<string>();
+
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n").filter((line) => line.trim());
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as QueueLine;
+
+        switch (entry.type) {
+          case "insight":
+            insightMap.set(entry.data.id, entry.data);
+            break;
+          case "dequeue":
+            for (const id of entry.ids) {
+              dequeuedIds.add(id);
+            }
+            break;
+          case "flush":
+            state.lastFlushAt = entry.at;
+            break;
+          case "clear":
+            insightMap.clear();
+            dequeuedIds.clear();
+            break;
+        }
+      } catch {
+        // Skip malformed lines (fault tolerance)
+        log.debug(`Skipping malformed queue line: ${line.slice(0, 50)}...`);
+      }
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      log.warn(`Error reading queue file: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    // File doesn't exist = fresh queue
+  }
+
+  // Build final insights list (excluding dequeued)
+  for (const [id, insight] of insightMap) {
+    if (!dequeuedIds.has(id)) {
+      state.insights.push(insight);
+    }
+  }
+
+  // Sort by queuedAt (FIFO)
+  state.insights.sort((a, b) => a.queuedAt - b.queuedAt);
+
+  return state;
+}
+
+/**
+ * Append a line to the queue file.
+ */
+async function appendLine(filePath: string, line: QueueLine): Promise<void> {
+  // Ensure directory exists
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+  const content = JSON.stringify(line) + "\n";
+  await fs.appendFile(filePath, content, "utf-8");
+}
+
+/**
+ * Create a digest accumulator with JSONL persistence.
+ */
+export function createAccumulator(config: DigestConfig): DigestAccumulator {
+  const filePath = config.storePath;
+  const cooldownMs = config.cooldownHours * 60 * 60 * 1000;
+  const maxFlushIntervalMs = config.maxHoursBetweenFlushes * 60 * 60 * 1000;
+
+  // Cache for lastFlushAt to avoid reading file repeatedly
+  let cachedLastFlushAt: number | null = null;
+
+  return {
+    async enqueue(insight: QueuedInsight): Promise<void> {
+      await appendLine(filePath, { type: "insight", data: insight });
+      log.debug(`Enqueued insight: ${insight.id} (${insight.topic})`);
+    },
+
+    async getQueue(): Promise<QueuedInsight[]> {
+      const state = await parseQueueFile(filePath);
+      cachedLastFlushAt = state.lastFlushAt;
+      return state.insights;
+    },
+
+    async getSettledInsights(): Promise<QueuedInsight[]> {
+      const queue = await this.getQueue();
+      const now = Date.now();
+      return queue.filter((insight) => now - insight.queuedAt >= cooldownMs);
+    },
+
+    async dequeue(ids: string[]): Promise<void> {
+      if (ids.length === 0) return;
+      await appendLine(filePath, { type: "dequeue", ids });
+      log.debug(`Dequeued ${ids.length} insights`);
+    },
+
+    shouldFlush(settled: QueuedInsight[]): FlushDecision {
+      // Count-based trigger
+      if (settled.length >= config.minInsightsToFlush) {
+        return { should: true, trigger: "count" };
+      }
+
+      // Time-based trigger (only if we have any settled insights)
+      if (settled.length > 0 && cachedLastFlushAt !== null) {
+        const now = Date.now();
+        const timeSinceLastFlush = now - cachedLastFlushAt;
+        if (timeSinceLastFlush >= maxFlushIntervalMs) {
+          return { should: true, trigger: "time" };
+        }
+      }
+
+      // Time trigger for first flush (lastFlushAt = 0)
+      if (settled.length > 0 && cachedLastFlushAt === 0) {
+        // For first flush, use queuedAt of oldest insight
+        const oldest = settled[0];
+        const now = Date.now();
+        if (now - oldest.queuedAt >= maxFlushIntervalMs) {
+          return { should: true, trigger: "time" };
+        }
+      }
+
+      return { should: false, trigger: null };
+    },
+
+    async recordFlush(): Promise<void> {
+      const now = Date.now();
+      await appendLine(filePath, { type: "flush", at: now });
+      cachedLastFlushAt = now;
+      log.debug(`Recorded flush at ${new Date(now).toISOString()}`);
+    },
+
+    async getLastFlushAt(): Promise<number> {
+      if (cachedLastFlushAt !== null) {
+        return cachedLastFlushAt;
+      }
+      const state = await parseQueueFile(filePath);
+      cachedLastFlushAt = state.lastFlushAt;
+      return state.lastFlushAt;
+    },
+
+    async clear(): Promise<void> {
+      await appendLine(filePath, { type: "clear" });
+      cachedLastFlushAt = 0;
+      log.debug("Queue cleared");
+    },
+  };
+}

--- a/src/cadence/responders/insight-digest/index.test.ts
+++ b/src/cadence/responders/insight-digest/index.test.ts
@@ -1,0 +1,613 @@
+/**
+ * Insight Digest responder integration tests.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createSignalBus } from "../../signal-bus.js";
+import type { OpenClawSignal } from "../../signals.js";
+import { createInsightDigestResponder, createAccumulator } from "./index.js";
+import type { DigestConfig, DigestClock } from "./types.js";
+
+const baseConfig: DigestConfig = {
+  minInsightsToFlush: 3,
+  maxHoursBetweenFlushes: 12,
+  quietHoursStart: "22:00",
+  quietHoursEnd: "08:00",
+  timezone: "UTC",
+  cooldownHours: 0, // No cooldown for testing
+  storePath: "",
+  checkIntervalMs: 100, // Fast for testing
+};
+
+function createMockClock(quiet: boolean = false): DigestClock {
+  return {
+    isQuietPeriod: vi.fn().mockReturnValue(quiet),
+    msUntilNextWindow: vi.fn().mockReturnValue(quiet ? 1000 : 0),
+    now: () => Date.now(),
+  };
+}
+
+function createExtractedSignal(insights: Array<{ id: string; topic: string }>): OpenClawSignal {
+  return {
+    type: "journal.insight.extracted",
+    id: `sig-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    ts: Date.now(),
+    payload: {
+      source: {
+        signalType: "obsidian.note.modified",
+        signalId: "parent-signal",
+        path: "/vault/journal/test.md",
+        contentHash: "abc123",
+      },
+      insights: insights.map((i) => ({
+        id: i.id,
+        topic: i.topic,
+        pillar: "norse",
+        hook: `Hook for ${i.topic}`,
+        excerpt: `Excerpt for ${i.topic}`,
+        scores: { topicClarity: 0.8, publishReady: 0.7, novelty: 0.9 },
+        formats: ["thread"],
+      })),
+      extractedAt: Date.now(),
+      extractorVersion: "0.1.0-test",
+    },
+  };
+}
+
+let testDir: string;
+let testConfig: DigestConfig;
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  testDir = path.join(
+    os.tmpdir(),
+    `insight-digest-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await fs.mkdir(testDir, { recursive: true });
+  testConfig = { ...baseConfig, storePath: path.join(testDir, "queue.jsonl") };
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  try {
+    await fs.rm(testDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+});
+
+describe("Signal Subscription", () => {
+  it("subscribes to journal.insight.extracted", async () => {
+    const bus = createSignalBus<OpenClawSignal>();
+    const responder = createInsightDigestResponder({
+      config: testConfig,
+      clock: createMockClock(),
+    });
+
+    const unsub = responder.register(bus);
+
+    const signal = createExtractedSignal([{ id: "1", topic: "Test" }]);
+    await bus.emit(signal);
+
+    // Verify insight was queued
+    const accumulator = createAccumulator(testConfig);
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(1);
+
+    unsub();
+  });
+
+  it("enqueues insights from signal", async () => {
+    const bus = createSignalBus<OpenClawSignal>();
+    const responder = createInsightDigestResponder({
+      config: testConfig,
+      clock: createMockClock(),
+    });
+
+    responder.register(bus);
+
+    const signal = createExtractedSignal([
+      { id: "1", topic: "Topic One" },
+      { id: "2", topic: "Topic Two" },
+    ]);
+    await bus.emit(signal);
+
+    const accumulator = createAccumulator(testConfig);
+    const queue = await accumulator.getQueue();
+
+    expect(queue).toHaveLength(2);
+    expect(queue[0].topic).toBe("Topic One");
+    expect(queue[1].topic).toBe("Topic Two");
+  });
+
+  it("handles signals with multiple insights", async () => {
+    const bus = createSignalBus<OpenClawSignal>();
+    const responder = createInsightDigestResponder({
+      config: testConfig,
+      clock: createMockClock(),
+    });
+
+    responder.register(bus);
+
+    const signal = createExtractedSignal([
+      { id: "1", topic: "A" },
+      { id: "2", topic: "B" },
+      { id: "3", topic: "C" },
+      { id: "4", topic: "D" },
+      { id: "5", topic: "E" },
+    ]);
+    await bus.emit(signal);
+
+    const accumulator = createAccumulator(testConfig);
+    const queue = await accumulator.getQueue();
+
+    expect(queue).toHaveLength(5);
+  });
+
+  it("handles signals with zero insights", async () => {
+    const bus = createSignalBus<OpenClawSignal>();
+    const responder = createInsightDigestResponder({
+      config: testConfig,
+      clock: createMockClock(),
+    });
+
+    responder.register(bus);
+
+    const signal = createExtractedSignal([]);
+    await bus.emit(signal);
+
+    const accumulator = createAccumulator(testConfig);
+    const queue = await accumulator.getQueue();
+
+    expect(queue).toHaveLength(0);
+  });
+});
+
+describe("Flush Trigger", () => {
+  it("calls onFlush when count threshold met", async () => {
+    // Use real timers for this test due to timing issues with fake timers + async file I/O
+    vi.useRealTimers();
+
+    const bus = createSignalBus<OpenClawSignal>();
+    const onFlush = vi.fn().mockResolvedValue(undefined);
+
+    // Create a fresh temp dir for this test
+    const realTestDir = path.join(os.tmpdir(), `flush-test-${Date.now()}`);
+    await fs.mkdir(realTestDir, { recursive: true });
+
+    const config: DigestConfig = {
+      ...baseConfig,
+      storePath: path.join(realTestDir, "queue.jsonl"),
+      minInsightsToFlush: 3,
+      checkIntervalMs: 50, // Fast for real timer test
+    };
+
+    const responder = createInsightDigestResponder({
+      config,
+      clock: createMockClock(),
+      onFlush,
+    });
+
+    const unsub = responder.register(bus);
+
+    // Add 3 insights
+    await bus.emit(
+      createExtractedSignal([
+        { id: "1", topic: "A" },
+        { id: "2", topic: "B" },
+        { id: "3", topic: "C" },
+      ]),
+    );
+
+    // Wait for scheduler check (real time)
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush.mock.calls[0][0].insights).toHaveLength(3);
+    expect(onFlush.mock.calls[0][0].trigger).toBe("count");
+
+    unsub();
+    await fs.rm(realTestDir, { recursive: true, force: true });
+  });
+
+  it("calls onFlush when time threshold met", async () => {
+    // Use real timers for this test due to timing issues with fake timers + async file I/O
+    vi.useRealTimers();
+
+    // Create a fresh temp dir for this test
+    const realTestDir = path.join(os.tmpdir(), `time-flush-test-${Date.now()}`);
+    await fs.mkdir(realTestDir, { recursive: true });
+
+    const config: DigestConfig = {
+      ...baseConfig,
+      storePath: path.join(realTestDir, "queue.jsonl"),
+      minInsightsToFlush: 10, // High count threshold
+      maxHoursBetweenFlushes: 0.00001, // ~36ms - very short for testing
+      checkIntervalMs: 20,
+    };
+
+    const bus = createSignalBus<OpenClawSignal>();
+    const onFlush = vi.fn().mockResolvedValue(undefined);
+
+    const responder = createInsightDigestResponder({
+      config,
+      clock: createMockClock(),
+      onFlush,
+    });
+
+    const unsub = responder.register(bus);
+
+    // Add just 1 insight (under count threshold)
+    await bus.emit(createExtractedSignal([{ id: "1", topic: "A" }]));
+
+    // Wait for time trigger (real time)
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onFlush).toHaveBeenCalled();
+    expect(onFlush.mock.calls[0][0].trigger).toBe("time");
+
+    unsub();
+    await fs.rm(realTestDir, { recursive: true, force: true });
+  });
+
+  it("does NOT call onFlush during quiet hours", async () => {
+    const bus = createSignalBus<OpenClawSignal>();
+    const onFlush = vi.fn();
+    const quietClock = createMockClock(true); // Always quiet
+
+    const responder = createInsightDigestResponder({
+      config: { ...testConfig, minInsightsToFlush: 2 },
+      clock: quietClock,
+      onFlush,
+    });
+
+    responder.register(bus);
+
+    // Add enough insights to trigger flush
+    await bus.emit(
+      createExtractedSignal([
+        { id: "1", topic: "A" },
+        { id: "2", topic: "B" },
+        { id: "3", topic: "C" },
+      ]),
+    );
+
+    // Multiple check cycles
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(testConfig.checkIntervalMs);
+    }
+
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onFlush when insights are fresh (cooldown)", async () => {
+    const config = {
+      ...testConfig,
+      minInsightsToFlush: 2,
+      cooldownHours: 1, // 1 hour cooldown
+    };
+
+    const bus = createSignalBus<OpenClawSignal>();
+    const onFlush = vi.fn();
+
+    const responder = createInsightDigestResponder({
+      config,
+      clock: createMockClock(),
+      onFlush,
+    });
+
+    responder.register(bus);
+
+    // Add insights (they're fresh)
+    await bus.emit(
+      createExtractedSignal([
+        { id: "1", topic: "A" },
+        { id: "2", topic: "B" },
+      ]),
+    );
+
+    // Check cycles (but not enough time for cooldown)
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(config.checkIntervalMs);
+    }
+
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("emits journal.digest.ready signal on flush", async () => {
+    // Use real timers for this test due to timing issues with fake timers + async file I/O
+    vi.useRealTimers();
+
+    // Create a fresh temp dir for this test
+    const realTestDir = path.join(os.tmpdir(), `signal-flush-test-${Date.now()}`);
+    await fs.mkdir(realTestDir, { recursive: true });
+
+    const config: DigestConfig = {
+      ...baseConfig,
+      storePath: path.join(realTestDir, "queue.jsonl"),
+      minInsightsToFlush: 2,
+      checkIntervalMs: 50,
+    };
+
+    const bus = createSignalBus<OpenClawSignal>();
+    const digestHandler = vi.fn();
+
+    bus.subscribe("journal.digest.ready", digestHandler);
+
+    const responder = createInsightDigestResponder({
+      config,
+      clock: createMockClock(),
+    });
+
+    const unsub = responder.register(bus);
+
+    await bus.emit(
+      createExtractedSignal([
+        { id: "1", topic: "A" },
+        { id: "2", topic: "B" },
+      ]),
+    );
+
+    // Wait for scheduler check (real time)
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(digestHandler).toHaveBeenCalledTimes(1);
+    expect(digestHandler.mock.calls[0][0].payload.insights).toHaveLength(2);
+
+    unsub();
+    await fs.rm(realTestDir, { recursive: true, force: true });
+  });
+
+  it("dequeues flushed insights", async () => {
+    // Use real timers for this test due to timing issues with fake timers + async file I/O
+    vi.useRealTimers();
+
+    // Create a fresh temp dir for this test
+    const realTestDir = path.join(os.tmpdir(), `dequeue-test-${Date.now()}`);
+    await fs.mkdir(realTestDir, { recursive: true });
+
+    const config: DigestConfig = {
+      ...baseConfig,
+      storePath: path.join(realTestDir, "queue.jsonl"),
+      minInsightsToFlush: 2,
+      checkIntervalMs: 50,
+    };
+
+    const bus = createSignalBus<OpenClawSignal>();
+
+    const responder = createInsightDigestResponder({
+      config,
+      clock: createMockClock(),
+    });
+
+    const unsub = responder.register(bus);
+
+    await bus.emit(
+      createExtractedSignal([
+        { id: "1", topic: "A" },
+        { id: "2", topic: "B" },
+      ]),
+    );
+
+    // Wait for scheduler check (real time)
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Queue should be empty after flush
+    const accumulator = createAccumulator(config);
+    const queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(0);
+
+    unsub();
+    await fs.rm(realTestDir, { recursive: true, force: true });
+  });
+});
+
+describe("Integration", () => {
+  it("full flow: enqueue → settle → flush → dequeue", async () => {
+    // Use real timers for this test due to timing issues with fake timers + async file I/O
+    vi.useRealTimers();
+
+    // Create a fresh temp dir for this test
+    const realTestDir = path.join(os.tmpdir(), `full-flow-test-${Date.now()}`);
+    await fs.mkdir(realTestDir, { recursive: true });
+
+    const config: DigestConfig = {
+      ...baseConfig,
+      storePath: path.join(realTestDir, "queue.jsonl"),
+      minInsightsToFlush: 2,
+      cooldownHours: 0, // No cooldown for testing
+      checkIntervalMs: 50,
+    };
+
+    const bus = createSignalBus<OpenClawSignal>();
+    const onFlush = vi.fn().mockResolvedValue(undefined);
+
+    const responder = createInsightDigestResponder({
+      config,
+      clock: createMockClock(),
+      onFlush,
+    });
+
+    const unsub = responder.register(bus);
+
+    // 1. Enqueue insights
+    await bus.emit(
+      createExtractedSignal([
+        { id: "1", topic: "A" },
+        { id: "2", topic: "B" },
+      ]),
+    );
+
+    // Verify enqueued
+    let accumulator = createAccumulator(config);
+    let queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(2);
+
+    // 2. Wait for scheduler check (real time)
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 3. Verify flushed
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    // 4. Verify dequeued
+    accumulator = createAccumulator(config);
+    queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(0);
+
+    unsub();
+    await fs.rm(realTestDir, { recursive: true, force: true });
+  });
+
+  it("respects minInsightsToFlush config", async () => {
+    const bus = createSignalBus<OpenClawSignal>();
+    const onFlush = vi.fn();
+
+    const responder = createInsightDigestResponder({
+      config: { ...testConfig, minInsightsToFlush: 5 },
+      clock: createMockClock(),
+      onFlush,
+    });
+
+    responder.register(bus);
+
+    // Add 4 (under threshold)
+    await bus.emit(
+      createExtractedSignal([
+        { id: "1", topic: "A" },
+        { id: "2", topic: "B" },
+        { id: "3", topic: "C" },
+        { id: "4", topic: "D" },
+      ]),
+    );
+
+    await vi.advanceTimersByTimeAsync(testConfig.checkIntervalMs);
+
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Add 5th
+    await bus.emit(createExtractedSignal([{ id: "5", topic: "E" }]));
+
+    await vi.advanceTimersByTimeAsync(testConfig.checkIntervalMs);
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Cleanup", () => {
+  it("unsubscriber stops signal subscription", async () => {
+    const bus = createSignalBus<OpenClawSignal>();
+
+    const responder = createInsightDigestResponder({
+      config: testConfig,
+      clock: createMockClock(),
+    });
+
+    const unsub = responder.register(bus);
+
+    // Emit before unsubscribe
+    await bus.emit(createExtractedSignal([{ id: "1", topic: "A" }]));
+
+    let accumulator = createAccumulator(testConfig);
+    let queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(1);
+
+    // Unsubscribe
+    unsub();
+
+    // Emit after unsubscribe
+    await bus.emit(createExtractedSignal([{ id: "2", topic: "B" }]));
+
+    accumulator = createAccumulator(testConfig);
+    queue = await accumulator.getQueue();
+    expect(queue).toHaveLength(1); // Still just 1
+  });
+
+  it("unsubscriber stops scheduler", async () => {
+    const bus = createSignalBus<OpenClawSignal>();
+    const onFlush = vi.fn();
+
+    const responder = createInsightDigestResponder({
+      config: { ...testConfig, minInsightsToFlush: 1 },
+      clock: createMockClock(),
+      onFlush,
+    });
+
+    const unsub = responder.register(bus);
+
+    // Unsubscribe before any checks
+    unsub();
+
+    // Emit signal (won't be processed)
+    await bus.emit(createExtractedSignal([{ id: "1", topic: "A" }]));
+
+    // Advance past many check intervals
+    await vi.advanceTimersByTimeAsync(testConfig.checkIntervalMs * 10);
+
+    // No flush should have occurred
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+});
+
+describe("Error Handling", () => {
+  it("continues on enqueue error", async () => {
+    // This tests that errors in the signal handler don't crash the responder
+    const bus = createSignalBus<OpenClawSignal>();
+
+    // Use an invalid store path that will fail on first write
+    const badConfig = {
+      ...testConfig,
+      storePath: "/invalid/path/that/cannot/be/created/queue.jsonl",
+    };
+
+    const responder = createInsightDigestResponder({
+      config: badConfig,
+      clock: createMockClock(),
+    });
+
+    const unsub = responder.register(bus);
+
+    // This should not throw (error is caught internally by the bus)
+    await expect(bus.emit(createExtractedSignal([{ id: "1", topic: "A" }]))).resolves.not.toThrow();
+
+    unsub();
+  });
+
+  it("continues on flush callback error", async () => {
+    // Use real timers for this test due to timing issues with fake timers + async file I/O
+    vi.useRealTimers();
+
+    // Create a fresh temp dir for this test
+    const realTestDir = path.join(os.tmpdir(), `error-test-${Date.now()}`);
+    await fs.mkdir(realTestDir, { recursive: true });
+
+    const config: DigestConfig = {
+      ...baseConfig,
+      storePath: path.join(realTestDir, "queue.jsonl"),
+      minInsightsToFlush: 1,
+      checkIntervalMs: 50,
+    };
+
+    const bus = createSignalBus<OpenClawSignal>();
+    const onFlush = vi.fn().mockRejectedValue(new Error("Callback failed"));
+
+    const responder = createInsightDigestResponder({
+      config,
+      clock: createMockClock(),
+      onFlush,
+    });
+
+    const unsub = responder.register(bus);
+
+    await bus.emit(createExtractedSignal([{ id: "1", topic: "A" }]));
+
+    // Should not throw (real time)
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onFlush).toHaveBeenCalled();
+    unsub();
+    await fs.rm(realTestDir, { recursive: true, force: true });
+  });
+});

--- a/src/cadence/responders/insight-digest/index.ts
+++ b/src/cadence/responders/insight-digest/index.ts
@@ -1,0 +1,184 @@
+/**
+ * Insight Digest responder.
+ *
+ * Accumulates journal.insight.extracted signals and flushes them as batched
+ * digests based on count/time triggers. Respects quiet hours and cooldown
+ * periods to avoid surfacing insights too soon after writing.
+ *
+ * Emits journal.digest.ready signal when a digest is flushed.
+ */
+
+import crypto from "node:crypto";
+import path from "node:path";
+import os from "node:os";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { SignalBus } from "../../signal-bus.js";
+import type { OpenClawSignal } from "../../signals.js";
+import type { Responder } from "../index.js";
+import { createAccumulator, type DigestAccumulator } from "./accumulator.js";
+import { createDigestScheduler, type DigestScheduler } from "./scheduler.js";
+import type { DigestConfig, DigestFlush, QueuedInsight, DigestClock } from "./types.js";
+import { DEFAULT_DIGEST_CONFIG } from "./types.js";
+
+const log = createSubsystemLogger("cadence").child("insight-digest");
+
+export interface InsightDigestResponderOptions {
+  /** Partial config overrides */
+  config?: Partial<DigestConfig>;
+
+  /** Custom accumulator (for testing) */
+  accumulator?: DigestAccumulator;
+
+  /** Custom scheduler (for testing) */
+  scheduler?: DigestScheduler;
+
+  /** Custom clock (for testing/extension) */
+  clock?: DigestClock;
+
+  /** Callback when flush occurs (in addition to signal emission) */
+  onFlush?: (digest: DigestFlush) => Promise<void>;
+}
+
+/**
+ * Resolve the default store path.
+ */
+function resolveStorePath(): string {
+  const home = os.homedir();
+  return path.join(home, ".openclaw", "cadence", "digest-queue.jsonl");
+}
+
+/**
+ * Create the insight digest responder.
+ */
+export function createInsightDigestResponder(
+  options: InsightDigestResponderOptions = {},
+): Responder {
+  // Merge config with defaults
+  const config: DigestConfig = {
+    ...DEFAULT_DIGEST_CONFIG,
+    storePath: resolveStorePath(),
+    ...options.config,
+  };
+
+  // Create components (or use provided ones for testing)
+  const accumulator = options.accumulator ?? createAccumulator(config);
+  const scheduler = options.scheduler ?? createDigestScheduler(config, options.clock);
+
+  return {
+    name: "insight-digest",
+    description: "Accumulates extracted insights and delivers periodic digests",
+
+    register(bus: SignalBus<OpenClawSignal>): () => void {
+      log.info("Insight digest responder starting", {
+        minInsights: config.minInsightsToFlush,
+        maxHours: config.maxHoursBetweenFlushes,
+        quietHours: `${config.quietHoursStart}-${config.quietHoursEnd}`,
+        cooldownHours: config.cooldownHours,
+      });
+
+      // Subscribe to insight.extracted signals
+      const unsubSignal = bus.subscribe("journal.insight.extracted", async (signal) => {
+        const { insights, source } = signal.payload;
+
+        for (const insight of insights) {
+          const queued: QueuedInsight = {
+            id: insight.id,
+            queuedAt: Date.now(),
+            sourceSignalId: signal.id,
+            sourcePath: source.path,
+            topic: insight.topic,
+            pillar: insight.pillar ?? undefined,
+            hook: insight.hook,
+            excerpt: insight.excerpt,
+            scores: insight.scores,
+            formats: insight.formats,
+          };
+
+          await accumulator.enqueue(queued);
+        }
+
+        if (insights.length > 0) {
+          log.debug(`Queued ${insights.length} insights from ${source.path}`);
+        }
+      });
+
+      // Schedule periodic flush checks
+      const unsubScheduler = scheduler.scheduleCheck(async () => {
+        // Skip during quiet hours
+        if (scheduler.isQuietHours()) {
+          log.debug("Skipping flush check: quiet hours");
+          return;
+        }
+
+        // Get settled insights (past cooldown)
+        const settled = await accumulator.getSettledInsights();
+        if (settled.length === 0) {
+          return;
+        }
+
+        // Check flush conditions
+        const { should, trigger } = accumulator.shouldFlush(settled);
+        if (!should || !trigger) {
+          return;
+        }
+
+        // Build digest
+        const digest: DigestFlush = {
+          flushedAt: Date.now(),
+          insights: settled,
+          trigger,
+        };
+
+        // Call optional callback
+        if (options.onFlush) {
+          try {
+            await options.onFlush(digest);
+          } catch (err) {
+            log.error(
+              `onFlush callback error: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+
+        // Emit signal for downstream consumers
+        await bus.emit({
+          type: "journal.digest.ready",
+          id: crypto.randomUUID(),
+          ts: Date.now(),
+          payload: {
+            flushedAt: digest.flushedAt,
+            insights: digest.insights.map((i) => ({
+              id: i.id,
+              topic: i.topic,
+              pillar: i.pillar,
+              hook: i.hook,
+              excerpt: i.excerpt,
+              scores: i.scores,
+              formats: i.formats,
+              sourcePath: i.sourcePath,
+            })),
+            trigger: digest.trigger,
+          },
+        });
+
+        // Record flush and dequeue
+        await accumulator.recordFlush();
+        await accumulator.dequeue(settled.map((i) => i.id));
+
+        log.info(`Flushed ${settled.length} insights (trigger: ${trigger})`);
+      });
+
+      // Return cleanup function
+      return () => {
+        unsubSignal();
+        unsubScheduler();
+        log.info("Insight digest responder stopped");
+      };
+    },
+  };
+}
+
+// Re-export types and utilities for testing
+export { createAccumulator } from "./accumulator.js";
+export { createDigestScheduler, createSimpleClock } from "./scheduler.js";
+export * from "./types.js";

--- a/src/cadence/responders/insight-digest/scheduler.test.ts
+++ b/src/cadence/responders/insight-digest/scheduler.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Scheduler tests — exhaustive coverage for time-based logic.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  parseTimeToMinutes,
+  getCurrentMinutesInTimezone,
+  isInQuietWindow,
+  msUntilQuietEnds,
+  createSimpleClock,
+  createDigestScheduler,
+} from "./scheduler.js";
+import type { DigestConfig } from "./types.js";
+
+const baseConfig: DigestConfig = {
+  minInsightsToFlush: 5,
+  maxHoursBetweenFlushes: 12,
+  quietHoursStart: "22:00",
+  quietHoursEnd: "08:00",
+  timezone: "America/New_York",
+  cooldownHours: 4,
+  storePath: "/tmp/test-digest.jsonl",
+  checkIntervalMs: 1000,
+};
+
+describe("parseTimeToMinutes", () => {
+  it("parses midnight", () => {
+    expect(parseTimeToMinutes("00:00")).toBe(0);
+  });
+
+  it("parses noon", () => {
+    expect(parseTimeToMinutes("12:00")).toBe(720);
+  });
+
+  it("parses 22:00", () => {
+    expect(parseTimeToMinutes("22:00")).toBe(22 * 60);
+  });
+
+  it("parses 08:00", () => {
+    expect(parseTimeToMinutes("08:00")).toBe(8 * 60);
+  });
+
+  it("parses 23:59", () => {
+    expect(parseTimeToMinutes("23:59")).toBe(23 * 60 + 59);
+  });
+
+  it("parses 00:30", () => {
+    expect(parseTimeToMinutes("00:30")).toBe(30);
+  });
+
+  it("throws on invalid format", () => {
+    expect(() => parseTimeToMinutes("25:00")).toThrow("Invalid time format");
+    expect(() => parseTimeToMinutes("12:60")).toThrow("Invalid time format");
+    expect(() => parseTimeToMinutes("abc")).toThrow("Invalid time format");
+    expect(() => parseTimeToMinutes("12")).toThrow("Invalid time format");
+    expect(() => parseTimeToMinutes("")).toThrow("Invalid time format");
+  });
+
+  it("throws on negative values", () => {
+    expect(() => parseTimeToMinutes("-1:00")).toThrow("Invalid time format");
+  });
+});
+
+describe("getCurrentMinutesInTimezone", () => {
+  it("returns minutes in valid timezone", () => {
+    // Use a fixed timestamp: 2024-01-15 14:30 UTC
+    const ts = Date.UTC(2024, 0, 15, 14, 30, 0);
+    const minutes = getCurrentMinutesInTimezone("UTC", ts);
+    expect(minutes).toBe(14 * 60 + 30);
+  });
+
+  it("handles timezone offset", () => {
+    // 14:30 UTC = 09:30 EST (UTC-5)
+    const ts = Date.UTC(2024, 0, 15, 14, 30, 0);
+    const minutes = getCurrentMinutesInTimezone("America/New_York", ts);
+    expect(minutes).toBe(9 * 60 + 30);
+  });
+
+  it("falls back to local time on invalid timezone", () => {
+    const ts = Date.now();
+    // Should not throw, should return some valid number
+    const minutes = getCurrentMinutesInTimezone("Invalid/Timezone", ts);
+    expect(minutes).toBeGreaterThanOrEqual(0);
+    expect(minutes).toBeLessThan(24 * 60);
+  });
+});
+
+describe("isInQuietWindow", () => {
+  describe("Normal window (same day)", () => {
+    // 09:00 to 17:00
+    const start = 9 * 60;
+    const end = 17 * 60;
+
+    it("returns true at start boundary", () => {
+      expect(isInQuietWindow(start, start, end)).toBe(true);
+    });
+
+    it("returns false at end boundary", () => {
+      expect(isInQuietWindow(end, start, end)).toBe(false);
+    });
+
+    it("returns true during window", () => {
+      expect(isInQuietWindow(12 * 60, start, end)).toBe(true);
+    });
+
+    it("returns false before window", () => {
+      expect(isInQuietWindow(8 * 60, start, end)).toBe(false);
+    });
+
+    it("returns false after window", () => {
+      expect(isInQuietWindow(18 * 60, start, end)).toBe(false);
+    });
+  });
+
+  describe("Wrap-around window (crosses midnight)", () => {
+    // 22:00 to 08:00
+    const start = 22 * 60;
+    const end = 8 * 60;
+
+    it("returns true at start boundary (22:00)", () => {
+      expect(isInQuietWindow(start, start, end)).toBe(true);
+    });
+
+    it("returns false at end boundary (08:00)", () => {
+      expect(isInQuietWindow(end, start, end)).toBe(false);
+    });
+
+    it("returns true during evening (23:00)", () => {
+      expect(isInQuietWindow(23 * 60, start, end)).toBe(true);
+    });
+
+    it("returns true at midnight (00:00)", () => {
+      expect(isInQuietWindow(0, start, end)).toBe(true);
+    });
+
+    it("returns true during morning (05:00)", () => {
+      expect(isInQuietWindow(5 * 60, start, end)).toBe(true);
+    });
+
+    it("returns false just before start (21:59)", () => {
+      expect(isInQuietWindow(21 * 60 + 59, start, end)).toBe(false);
+    });
+
+    it("returns false just after end (08:01)", () => {
+      expect(isInQuietWindow(8 * 60 + 1, start, end)).toBe(false);
+    });
+
+    it("returns false during day (12:00)", () => {
+      expect(isInQuietWindow(12 * 60, start, end)).toBe(false);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("returns false when start === end (disabled)", () => {
+      expect(isInQuietWindow(12 * 60, 8 * 60, 8 * 60)).toBe(false);
+    });
+
+    it("handles just before midnight (23:59)", () => {
+      expect(isInQuietWindow(23 * 60 + 59, 22 * 60, 8 * 60)).toBe(true);
+    });
+
+    it("handles just after midnight (00:01)", () => {
+      expect(isInQuietWindow(1, 22 * 60, 8 * 60)).toBe(true);
+    });
+  });
+});
+
+describe("msUntilQuietEnds", () => {
+  describe("Wrap-around window (22:00-08:00)", () => {
+    const start = 22 * 60;
+    const end = 8 * 60;
+
+    it("returns 0 when not in quiet hours", () => {
+      expect(msUntilQuietEnds(12 * 60, start, end)).toBe(0);
+    });
+
+    it("returns correct ms at 22:00", () => {
+      // From 22:00 to 08:00 = 10 hours = 600 minutes
+      expect(msUntilQuietEnds(22 * 60, start, end)).toBe(600 * 60 * 1000);
+    });
+
+    it("returns correct ms at 23:00", () => {
+      // From 23:00 to 08:00 = 9 hours = 540 minutes
+      expect(msUntilQuietEnds(23 * 60, start, end)).toBe(540 * 60 * 1000);
+    });
+
+    it("returns correct ms at midnight", () => {
+      // From 00:00 to 08:00 = 8 hours = 480 minutes
+      expect(msUntilQuietEnds(0, start, end)).toBe(480 * 60 * 1000);
+    });
+
+    it("returns correct ms at 05:00", () => {
+      // From 05:00 to 08:00 = 3 hours = 180 minutes
+      expect(msUntilQuietEnds(5 * 60, start, end)).toBe(180 * 60 * 1000);
+    });
+
+    it("returns correct ms at 07:59", () => {
+      // From 07:59 to 08:00 = 1 minute
+      expect(msUntilQuietEnds(7 * 60 + 59, start, end)).toBe(1 * 60 * 1000);
+    });
+  });
+
+  describe("Normal window (09:00-17:00)", () => {
+    const start = 9 * 60;
+    const end = 17 * 60;
+
+    it("returns correct ms at 09:00", () => {
+      // From 09:00 to 17:00 = 8 hours
+      expect(msUntilQuietEnds(9 * 60, start, end)).toBe(8 * 60 * 60 * 1000);
+    });
+
+    it("returns correct ms at 12:00", () => {
+      // From 12:00 to 17:00 = 5 hours
+      expect(msUntilQuietEnds(12 * 60, start, end)).toBe(5 * 60 * 60 * 1000);
+    });
+  });
+});
+
+describe("createSimpleClock", () => {
+  it("creates clock with config timezone", () => {
+    const clock = createSimpleClock(baseConfig);
+    expect(clock).toBeDefined();
+    expect(typeof clock.isQuietPeriod).toBe("function");
+    expect(typeof clock.msUntilNextWindow).toBe("function");
+    expect(typeof clock.now).toBe("function");
+  });
+
+  it("now() returns current time", () => {
+    const clock = createSimpleClock(baseConfig);
+    const before = Date.now();
+    const now = clock.now();
+    const after = Date.now();
+    expect(now).toBeGreaterThanOrEqual(before);
+    expect(now).toBeLessThanOrEqual(after);
+  });
+});
+
+describe("createDigestScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("creates scheduler with default clock", () => {
+    const scheduler = createDigestScheduler(baseConfig);
+    expect(scheduler).toBeDefined();
+    expect(scheduler.clock).toBeDefined();
+  });
+
+  it("creates scheduler with custom clock", () => {
+    const customClock = {
+      isQuietPeriod: () => false,
+      msUntilNextWindow: () => 0,
+      now: () => Date.now(),
+    };
+    const scheduler = createDigestScheduler(baseConfig, customClock);
+    expect(scheduler.clock).toBe(customClock);
+  });
+
+  it("isQuietHours delegates to clock", () => {
+    const customClock = {
+      isQuietPeriod: vi.fn().mockReturnValue(true),
+      msUntilNextWindow: () => 0,
+      now: () => Date.now(),
+    };
+    const scheduler = createDigestScheduler(baseConfig, customClock);
+
+    expect(scheduler.isQuietHours()).toBe(true);
+    expect(customClock.isQuietPeriod).toHaveBeenCalled();
+  });
+
+  it("msUntilNextWindow delegates to clock", () => {
+    const customClock = {
+      isQuietPeriod: () => true,
+      msUntilNextWindow: vi.fn().mockReturnValue(5000),
+      now: () => Date.now(),
+    };
+    const scheduler = createDigestScheduler(baseConfig, customClock);
+
+    expect(scheduler.msUntilNextWindow()).toBe(5000);
+    expect(customClock.msUntilNextWindow).toHaveBeenCalled();
+  });
+
+  describe("scheduleCheck", () => {
+    it("calls callback after interval", async () => {
+      const scheduler = createDigestScheduler(baseConfig);
+      const callback = vi.fn().mockResolvedValue(undefined);
+
+      const unsub = scheduler.scheduleCheck(callback);
+
+      expect(callback).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(baseConfig.checkIntervalMs);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      unsub();
+    });
+
+    it("schedules repeated checks", async () => {
+      const scheduler = createDigestScheduler(baseConfig);
+      const callback = vi.fn().mockResolvedValue(undefined);
+
+      const unsub = scheduler.scheduleCheck(callback);
+
+      await vi.advanceTimersByTimeAsync(baseConfig.checkIntervalMs);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(baseConfig.checkIntervalMs);
+      expect(callback).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(baseConfig.checkIntervalMs);
+      expect(callback).toHaveBeenCalledTimes(3);
+
+      unsub();
+    });
+
+    it("unsubscriber stops checks", async () => {
+      const scheduler = createDigestScheduler(baseConfig);
+      const callback = vi.fn().mockResolvedValue(undefined);
+
+      const unsub = scheduler.scheduleCheck(callback);
+
+      await vi.advanceTimersByTimeAsync(baseConfig.checkIntervalMs);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      unsub();
+
+      await vi.advanceTimersByTimeAsync(baseConfig.checkIntervalMs * 10);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles callback errors gracefully", async () => {
+      const scheduler = createDigestScheduler(baseConfig);
+      const callback = vi.fn().mockRejectedValue(new Error("Callback failed"));
+
+      const unsub = scheduler.scheduleCheck(callback);
+
+      await vi.advanceTimersByTimeAsync(baseConfig.checkIntervalMs);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // Should continue scheduling despite error
+      await vi.advanceTimersByTimeAsync(baseConfig.checkIntervalMs);
+      expect(callback).toHaveBeenCalledTimes(2);
+
+      unsub();
+    });
+  });
+});

--- a/src/cadence/responders/insight-digest/scheduler.ts
+++ b/src/cadence/responders/insight-digest/scheduler.ts
@@ -1,0 +1,194 @@
+/**
+ * Digest scheduler — time-based flush triggers and quiet hours.
+ *
+ * Follows heartbeat pattern from src/infra/heartbeat-runner.ts.
+ * Designed to be clock-pluggable for future biological timing models.
+ */
+
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { DigestConfig, DigestClock } from "./types.js";
+
+const log = createSubsystemLogger("cadence").child("digest-scheduler");
+
+/**
+ * Parse HH:MM time string to minutes since midnight.
+ */
+export function parseTimeToMinutes(time: string): number {
+  const [hours, minutes] = time.split(":").map(Number);
+  if (isNaN(hours) || isNaN(minutes) || hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+    throw new Error(`Invalid time format: ${time}. Expected HH:MM.`);
+  }
+  return hours * 60 + minutes;
+}
+
+/**
+ * Get current minutes since midnight in a specific timezone.
+ */
+export function getCurrentMinutesInTimezone(timezone: string, now: number = Date.now()): number {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "numeric",
+      minute: "numeric",
+      hour12: false,
+    });
+    const parts = formatter.formatToParts(new Date(now));
+    const hour = parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10);
+    const minute = parseInt(parts.find((p) => p.type === "minute")?.value ?? "0", 10);
+    return hour * 60 + minute;
+  } catch {
+    // Fallback to local time if timezone is invalid
+    log.warn(`Invalid timezone "${timezone}", falling back to local time`);
+    const date = new Date(now);
+    return date.getHours() * 60 + date.getMinutes();
+  }
+}
+
+/**
+ * Check if a given time (in minutes) is within a quiet window.
+ * Handles wrap-around (e.g., 22:00 to 08:00 crosses midnight).
+ */
+export function isInQuietWindow(
+  currentMinutes: number,
+  startMinutes: number,
+  endMinutes: number,
+): boolean {
+  // Same start and end = quiet hours disabled
+  if (startMinutes === endMinutes) {
+    return false;
+  }
+
+  // Check for 24-hour quiet (start > end by full day, though unusual)
+  // This would mean quiet all day, but let's treat it as no quiet hours
+
+  if (startMinutes < endMinutes) {
+    // Normal window (e.g., 09:00 to 17:00)
+    return currentMinutes >= startMinutes && currentMinutes < endMinutes;
+  } else {
+    // Wrap-around window (e.g., 22:00 to 08:00)
+    // Quiet if >= start OR < end
+    return currentMinutes >= startMinutes || currentMinutes < endMinutes;
+  }
+}
+
+/**
+ * Calculate milliseconds until the quiet window ends.
+ * Returns 0 if not currently in quiet hours.
+ */
+export function msUntilQuietEnds(
+  currentMinutes: number,
+  startMinutes: number,
+  endMinutes: number,
+): number {
+  if (!isInQuietWindow(currentMinutes, startMinutes, endMinutes)) {
+    return 0;
+  }
+
+  let minutesUntilEnd: number;
+
+  if (startMinutes < endMinutes) {
+    // Normal window
+    minutesUntilEnd = endMinutes - currentMinutes;
+  } else {
+    // Wrap-around window
+    if (currentMinutes >= startMinutes) {
+      // We're in the evening portion (after start, before midnight)
+      // Minutes until midnight + minutes from midnight to end
+      minutesUntilEnd = 24 * 60 - currentMinutes + endMinutes;
+    } else {
+      // We're in the morning portion (after midnight, before end)
+      minutesUntilEnd = endMinutes - currentMinutes;
+    }
+  }
+
+  return minutesUntilEnd * 60 * 1000;
+}
+
+/**
+ * Simple clock implementation using config-based quiet hours.
+ */
+export function createSimpleClock(config: DigestConfig): DigestClock {
+  const startMinutes = parseTimeToMinutes(config.quietHoursStart);
+  const endMinutes = parseTimeToMinutes(config.quietHoursEnd);
+
+  return {
+    isQuietPeriod(): boolean {
+      const currentMinutes = getCurrentMinutesInTimezone(config.timezone);
+      return isInQuietWindow(currentMinutes, startMinutes, endMinutes);
+    },
+
+    msUntilNextWindow(): number {
+      const currentMinutes = getCurrentMinutesInTimezone(config.timezone);
+      return msUntilQuietEnds(currentMinutes, startMinutes, endMinutes);
+    },
+
+    now(): number {
+      return Date.now();
+    },
+  };
+}
+
+export interface DigestScheduler {
+  /** Check if currently in quiet hours */
+  isQuietHours(): boolean;
+
+  /** Schedule periodic flush checks */
+  scheduleCheck(callback: () => Promise<void>): () => void;
+
+  /** Get ms until next allowed flush window */
+  msUntilNextWindow(): number;
+
+  /** The underlying clock (for testing/extension) */
+  clock: DigestClock;
+}
+
+/**
+ * Create a digest scheduler with configurable clock.
+ */
+export function createDigestScheduler(config: DigestConfig, clock?: DigestClock): DigestScheduler {
+  const activeClock = clock ?? createSimpleClock(config);
+  let checkTimer: NodeJS.Timeout | null = null;
+
+  return {
+    clock: activeClock,
+
+    isQuietHours(): boolean {
+      return activeClock.isQuietPeriod();
+    },
+
+    msUntilNextWindow(): number {
+      return activeClock.msUntilNextWindow();
+    },
+
+    scheduleCheck(callback: () => Promise<void>): () => void {
+      let stopped = false;
+
+      const runCheck = async () => {
+        if (stopped) return;
+
+        try {
+          await callback();
+        } catch (err) {
+          log.error(`Flush check error: ${err instanceof Error ? err.message : String(err)}`);
+        }
+
+        // Schedule next check if not stopped
+        if (!stopped) {
+          checkTimer = setTimeout(runCheck, config.checkIntervalMs);
+        }
+      };
+
+      // Start the first check after the interval
+      checkTimer = setTimeout(runCheck, config.checkIntervalMs);
+
+      // Return unsubscriber
+      return () => {
+        stopped = true;
+        if (checkTimer) {
+          clearTimeout(checkTimer);
+          checkTimer = null;
+        }
+      };
+    },
+  };
+}

--- a/src/cadence/responders/insight-digest/types.ts
+++ b/src/cadence/responders/insight-digest/types.ts
@@ -1,0 +1,129 @@
+/**
+ * Insight Digest types.
+ *
+ * Architecture note: The scheduler interface is designed to be "clock-pluggable"
+ * so we can later swap in biological timing models (circadian rhythm, ultradian
+ * cycles, HippoRAG-style memory consolidation windows, etc.).
+ */
+
+export interface DigestConfig {
+  /** Minimum insights before triggering a flush (default: 5) */
+  minInsightsToFlush: number;
+
+  /** Force flush after this many hours even if under count (default: 12) */
+  maxHoursBetweenFlushes: number;
+
+  /** Don't disturb start time in HH:MM format (default: "22:00") */
+  quietHoursStart: string;
+
+  /** Don't disturb end time in HH:MM format (default: "08:00") */
+  quietHoursEnd: string;
+
+  /** Timezone for quiet hours calculation (default: "America/New_York") */
+  timezone: string;
+
+  /** Hours to wait before surfacing insights from recent edits (default: 4) */
+  cooldownHours: number;
+
+  /** Path to JSONL queue file */
+  storePath: string;
+
+  /** Interval in ms between flush checks (default: 60000 = 1 minute) */
+  checkIntervalMs: number;
+}
+
+export const DEFAULT_DIGEST_CONFIG: DigestConfig = {
+  minInsightsToFlush: 5,
+  maxHoursBetweenFlushes: 12,
+  quietHoursStart: "22:00",
+  quietHoursEnd: "08:00",
+  timezone: "America/New_York",
+  cooldownHours: 4,
+  storePath: "", // Resolved at runtime to ~/.openclaw/cadence/digest-queue.jsonl
+  checkIntervalMs: 60_000,
+};
+
+export interface QueuedInsight {
+  /** Unique ID from extracted insight */
+  id: string;
+
+  /** When this insight was added to the queue */
+  queuedAt: number;
+
+  /** ID of the parent signal that produced this insight */
+  sourceSignalId: string;
+
+  /** Original file path the insight came from */
+  sourcePath: string;
+
+  /** Insight topic */
+  topic: string;
+
+  /** Content pillar (optional) */
+  pillar?: string;
+
+  /** Hook/teaser text */
+  hook: string;
+
+  /** Excerpt from source */
+  excerpt: string;
+
+  /** Quality scores */
+  scores: {
+    topicClarity: number;
+    publishReady: number;
+    novelty: number;
+  };
+
+  /** Suggested output formats */
+  formats: string[];
+}
+
+export interface DigestFlush {
+  /** When the flush occurred */
+  flushedAt: number;
+
+  /** Insights included in this flush */
+  insights: QueuedInsight[];
+
+  /** What triggered this flush */
+  trigger: "count" | "time" | "manual";
+}
+
+export type FlushTrigger = "count" | "time" | null;
+
+export interface FlushDecision {
+  should: boolean;
+  trigger: FlushTrigger;
+}
+
+/**
+ * Clock interface for timing decisions.
+ *
+ * This abstraction allows swapping in different timing models:
+ * - SimpleScheduler: Basic quiet hours + interval checks
+ * - CircadianClock: Follows natural alertness cycles
+ * - UltradianClock: 90-minute focus/rest cycles
+ * - ConsolidationClock: HippoRAG-style memory consolidation windows
+ */
+export interface DigestClock {
+  /** Check if current time is in a "quiet" period (no notifications) */
+  isQuietPeriod(): boolean;
+
+  /** Get milliseconds until next active window */
+  msUntilNextWindow(): number;
+
+  /** Get current time (for testability) */
+  now(): number;
+}
+
+/**
+ * Queue state persisted to JSONL.
+ */
+export interface QueueState {
+  /** Last time a flush occurred (0 if never) */
+  lastFlushAt: number;
+
+  /** Queued insights awaiting flush */
+  insights: QueuedInsight[];
+}

--- a/src/cadence/signals.ts
+++ b/src/cadence/signals.ts
@@ -74,14 +74,57 @@ export type OpenClawPayloadMap = {
     data: Record<string, unknown>;
   };
 
-  /** Journal insight extracted (PR-Firm pipeline) */
+  /** Journal insight extracted (P1 content pipeline) */
   "journal.insight.extracted": {
-    path: string;
-    insights: string[];
-    category: string;
+    source: {
+      signalType: string;
+      signalId: string;
+      path: string;
+      contentHash: string;
+    };
+    insights: Array<{
+      id: string;
+      topic: string;
+      pillar?: string;
+      hook: string;
+      excerpt: string;
+      scores: {
+        topicClarity: number;
+        publishReady: number;
+        novelty: number;
+      };
+      formats: string[];
+      concepts?: Array<{
+        name: string;
+        type: "entity" | "concept" | "theme";
+        confidence: number;
+      }>;
+    }>;
+    extractedAt: number;
+    extractorVersion: string;
   };
 
-  /** Draft generated from insights (PR-Firm pipeline) */
+  /** Digest ready for delivery (batched insights) */
+  "journal.digest.ready": {
+    flushedAt: number;
+    insights: Array<{
+      id: string;
+      topic: string;
+      pillar?: string;
+      hook: string;
+      excerpt: string;
+      scores: {
+        topicClarity: number;
+        publishReady: number;
+        novelty: number;
+      };
+      formats: string[];
+      sourcePath: string;
+    }>;
+    trigger: "count" | "time" | "manual";
+  };
+
+  /** Draft generated from insights (P1 content pipeline) */
   "draft.generated": {
     draftId: string;
     platform: "twitter" | "linkedin" | "blog";


### PR DESCRIPTION
## Summary

Adds the **Insight Digest** responder — accumulates `journal.insight.extracted` signals and flushes them as batched digests based on count/time triggers.

### Key Features

- **JSONL Accumulator**: Fault-tolerant append-only storage with line types (`insight`, `dequeue`, `flush`, `clear`)
- **Time-based Scheduler**: Periodic flush checks with quiet hours support (handles midnight crossover)
- **Clock-pluggable Interface**: `DigestClock` abstraction for future biological timing models (circadian rhythm, HippoRAG, etc.)
- **Configurable Triggers**:
  - `minInsightsToFlush`: Minimum batch size before triggering
  - `maxHoursBetweenFlushes`: Time-based backup flush
  - `cooldownHours`: Wait period before surfacing recent insights
  - Quiet hours with timezone support

### Files Added

```
src/cadence/responders/insight-digest/
├── types.ts              # Core interfaces (DigestConfig, DigestClock, QueuedInsight)
├── accumulator.ts        # JSONL storage + flush logic
├── scheduler.ts          # Time-based flush triggers + quiet hours
├── index.ts              # Responder factory wiring
├── accumulator.test.ts   # 39 tests
├── scheduler.test.ts     # 41 tests
└── index.test.ts         # 16 integration tests
```

### Signal Types

- **Input**: `journal.insight.extracted` (enhanced payload structure)
- **Output**: `journal.digest.ready` (new signal type for downstream consumers)

## Test plan

- [x] All 96 unit tests pass
- [x] Lint clean
- [x] Signal subscription verified
- [x] Flush triggers (count + time) verified
- [x] Quiet hours blocking verified
- [x] Cooldown period verified
- [x] Error handling (continues on callback errors)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)