### PR TITLE
docs: Add landing page for docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
@@ -32,12 +33,12 @@ jobs:
         run: pip install mkdocs
 
       - name: Build docs
-        run: cd docs && mkdocs build
+        run: mkdocs build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/site
+          path: site
 
   deploy:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .env
 docker-compose.extra.yml
 dist
+site
 *.bun-build
 pnpm-lock.yaml
 bun.lock

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,249 +1,63 @@
----
-summary: "Top-level overview of OpenClaw, features, and purpose"
-read_when:
-  - Introducing OpenClaw to newcomers
----
-# OpenClaw 🦞
+# OpenClaw
 
-> *"EXFOLIATE! EXFOLIATE!"* — A space lobster, probably
-
-
-<p align="center">
-    <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text-dark.png">
-        <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="OpenClaw" width="500">
-    </picture>
+<p align="center" style="font-size: 4em; margin: 0.5em 0;">
+  <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="OpenClaw" width="360">
 </p>
 
-
-<p align="center">
-  <strong>Any OS + WhatsApp/Telegram/Discord/iMessage gateway for AI agents (Pi).</strong><br />
-  Plugins add Mattermost and more.
-  Send a message, get an agent response — from your pocket.
+<p align="center" style="font-style: italic; color: #888; margin-bottom: 2em;">
+  This is not a fork. It's a claw with opinions.
 </p>
-
-<p align="center">
-  <a href="https://github.com/openclaw/openclaw">GitHub</a> ·
-  <a href="https://github.com/openclaw/openclaw/releases">Releases</a> ·
-  <a href="/">Docs</a> ·
-  <a href="/start/openclaw">OpenClaw assistant setup</a>
-</p>
-
-OpenClaw bridges WhatsApp (via WhatsApp Web / Baileys), Telegram (Bot API / grammY), Discord (Bot API / channels.discord.js), and iMessage (imsg CLI) to coding agents like [Pi](https://github.com/badlogic/pi-mono). Plugins add Mattermost (Bot API + WebSocket) and more.
-OpenClaw also powers the OpenClaw assistant.
-
-## Start here
-
-- **New install from zero:** [Getting Started](/start/getting-started)
-- **Guided setup (recommended):** [Wizard](/start/wizard) (`openclaw onboard`)
-- **Open the dashboard (local Gateway):** http://127.0.0.1:18789/ (or http://localhost:18789/)
-
-If the Gateway is running on the same computer, that link opens the browser Control UI
-immediately. If it fails, start the Gateway first: `openclaw gateway`.
-
-## Dashboard (browser Control UI)
-
-The dashboard is the browser Control UI for chat, config, nodes, sessions, and more.
-Local default: http://127.0.0.1:18789/
-Remote access: [Web surfaces](/web) and [Tailscale](/gateway/tailscale)
-
-<p align="center">
-  <img src="whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
-</p>
-
-## How it works
-
-```
-WhatsApp / Telegram / Discord / iMessage (+ plugins)
-        │
-        ▼
-  ┌───────────────────────────┐
-  │          Gateway          │  ws://127.0.0.1:18789 (loopback-only)
-  │     (single source)       │
-  │                           │  http://<gateway-host>:18793
-  │                           │    /__openclaw__/canvas/ (Canvas host)
-  └───────────┬───────────────┘
-              │
-              ├─ Pi agent (RPC)
-              ├─ CLI (openclaw …)
-              ├─ Chat UI (SwiftUI)
-              ├─ macOS app (OpenClaw.app)
-              ├─ iOS node via Gateway WS + pairing
-              └─ Android node via Gateway WS + pairing
-```
-
-Most operations flow through the **Gateway** (`openclaw gateway`), a single long-running process that owns channel connections and the WebSocket control plane.
-
-## Network model
-
-- **One Gateway per host (recommended)**: it is the only process allowed to own the WhatsApp Web session. If you need a rescue bot or strict isolation, run multiple gateways with isolated profiles and ports; see [Multiple gateways](/gateway/multiple-gateways).
-- **Loopback-first**: Gateway WS defaults to `ws://127.0.0.1:18789`.
-  - The wizard now generates a gateway token by default (even for loopback).
-  - For Tailnet access, run `openclaw gateway --bind tailnet --token ...` (token is required for non-loopback binds).
-- **Nodes**: connect to the Gateway WebSocket (LAN/tailnet/SSH as needed); legacy TCP bridge is deprecated/removed.
-- **Canvas host**: HTTP file server on `canvasHost.port` (default `18793`), serving `/__openclaw__/canvas/` for node WebViews; see [Gateway configuration](/gateway/configuration) (`canvasHost`).
-- **Remote use**: SSH tunnel or tailnet/VPN; see [Remote access](/gateway/remote) and [Discovery](/gateway/discovery).
-
-## Features (high level)
-
-- 📱 **WhatsApp Integration** — Uses Baileys for WhatsApp Web protocol
-- ✈️ **Telegram Bot** — DMs + groups via grammY
-- 🎮 **Discord Bot** — DMs + guild channels via channels.discord.js
-- 🧩 **Mattermost Bot (plugin)** — Bot token + WebSocket events
-- 💬 **iMessage** — Local imsg CLI integration (macOS)
-- 🤖 **Agent bridge** — Pi (RPC mode) with tool streaming
-- ⏱️ **Streaming + chunking** — Block streaming + Telegram draft streaming details ([/concepts/streaming](/concepts/streaming))
-- 🧠 **Multi-agent routing** — Route provider accounts/peers to isolated agents (workspace + per-agent sessions)
-- 🔐 **Subscription auth** — Anthropic (Claude Pro/Max) + OpenAI (ChatGPT/Codex) via OAuth
-- 💬 **Sessions** — Direct chats collapse into shared `main` (default); groups are isolated
-- 👥 **Group Chat Support** — Mention-based by default; owner can toggle `/activation always|mention`
-- 📎 **Media Support** — Send and receive images, audio, documents
-- 🎤 **Voice notes** — Optional transcription hook
-- 🖥️ **WebChat + macOS app** — Local UI + menu bar companion for ops and voice wake
-- 📱 **iOS node** — Pairs as a node and exposes a Canvas surface
-- 📱 **Android node** — Pairs as a node and exposes Canvas + Chat + Camera
-
-Note: legacy Claude/Codex/Gemini/Opencode paths have been removed; Pi is the only coding-agent path.
-
-## Quick start
-
-Runtime requirement: **Node ≥ 22**.
-
-```bash
-# Recommended: global install (npm/pnpm)
-npm install -g openclaw@latest
-# or: pnpm add -g openclaw@latest
-
-# Onboard + install the service (launchd/systemd user service)
-openclaw onboard --install-daemon
-
-# Pair WhatsApp Web (shows QR)
-openclaw channels login
-
-# Gateway runs via the service after onboarding; manual run is still possible:
-openclaw gateway --port 18789
-```
-
-Switching between npm and git installs later is easy: install the other flavor and run `openclaw doctor` to update the gateway service entrypoint.
-
-From source (development):
-
-```bash
-git clone https://github.com/openclaw/openclaw.git
-cd openclaw
-pnpm install
-pnpm ui:build # auto-installs UI deps on first run
-pnpm build
-openclaw onboard --install-daemon
-```
-
-If you don’t have a global install yet, run the onboarding step via `pnpm openclaw ...` from the repo.
-
-Multi-instance quickstart (optional):
-
-```bash
-OPENCLAW_CONFIG_PATH=~/.openclaw/a.json \
-OPENCLAW_STATE_DIR=~/.openclaw-a \
-openclaw gateway --port 19001
-```
-
-Send a test message (requires a running Gateway):
-
-```bash
-openclaw message send --target +15555550123 --message "Hello from OpenClaw"
-```
-
-## Configuration (optional)
-
-Config lives at `~/.openclaw/openclaw.json`.
-
-- If you **do nothing**, OpenClaw uses the bundled Pi binary in RPC mode with per-sender sessions.
-- If you want to lock it down, start with `channels.whatsapp.allowFrom` and (for groups) mention rules.
-
-Example:
-
-```json5
-{
-  channels: {
-    whatsapp: {
-      allowFrom: ["+15555550123"],
-      groups: { "*": { requireMention: true } }
-    }
-  },
-  messages: { groupChat: { mentionPatterns: ["@openclaw"] } }
-}
-```
-
-## Docs
-
-- Start here:
-  - [Docs hubs (all pages linked)](/start/hubs)
-  - [Help](/help) ← *common fixes + troubleshooting*
-  - [Configuration](/gateway/configuration)
-  - [Configuration examples](/gateway/configuration-examples)
-  - [Slash commands](/tools/slash-commands)
-  - [Multi-agent routing](/concepts/multi-agent)
-  - [Updating / rollback](/install/updating)
-  - [Pairing (DM + nodes)](/start/pairing)
-  - [Nix mode](/install/nix)
-  - [OpenClaw assistant setup](/start/openclaw)
-  - [Skills](/tools/skills)
-  - [Skills config](/tools/skills-config)
-  - [Workspace templates](/reference/templates/AGENTS)
-  - [RPC adapters](/reference/rpc)
-  - [Gateway runbook](/gateway)
-  - [Nodes (iOS/Android)](/nodes)
-  - [Web surfaces (Control UI)](/web)
-  - [Discovery + transports](/gateway/discovery)
-  - [Remote access](/gateway/remote)
-- Providers and UX:
-  - [WebChat](/web/webchat)
-  - [Control UI (browser)](/web/control-ui)
-  - [Telegram](/channels/telegram)
-  - [Discord](/channels/discord)
-  - [Mattermost (plugin)](/channels/mattermost)
-  - [iMessage](/channels/imessage)
-  - [Groups](/concepts/groups)
-  - [WhatsApp group messages](/concepts/group-messages)
-  - [Media: images](/nodes/images)
-  - [Media: audio](/nodes/audio)
-- Companion apps:
-  - [macOS app](/platforms/macos)
-  - [iOS app](/platforms/ios)
-  - [Android app](/platforms/android)
-  - [Windows (WSL2)](/platforms/windows)
-  - [Linux app](/platforms/linux)
-- Ops and safety:
-  - [Sessions](/concepts/session)
-  - [Cron jobs](/automation/cron-jobs)
-  - [Webhooks](/automation/webhook)
-  - [Gmail hooks (Pub/Sub)](/automation/gmail-pubsub)
-  - [Security](/gateway/security)
-  - [Troubleshooting](/gateway/troubleshooting)
-
-## The name
-
-**OpenClaw = CLAW + TARDIS** — because every space lobster needs a time-and-space machine.
 
 ---
 
-*"We're all just playing with our own prompts."* — an AI, probably high on tokens
+**OpenClaw** is an opinionated distribution of [openclaw](https://github.com/openclaw/openclaw) — the WhatsApp/Telegram/Discord/iMessage gateway for AI agents.
 
-## Credits
+This fork adds **observability layers** that make your AI usage accountable, measurable, and improvable:
 
-- **Peter Steinberger** ([@steipete](https://twitter.com/steipete)) — Creator, lobster whisperer
-- **Mario Zechner** ([@badlogicc](https://twitter.com/badlogicgames)) — Pi creator, security pen-tester
-- **Clawd** — The space lobster who demanded a better name
+## Modules
 
-## Core Contributors
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.5em; margin: 2em 0;">
 
-- **Maxim Vovshin** (@Hyaxia, 36747317+Hyaxia@users.noreply.github.com) — Blogwatcher skill
-- **Nacho Iacovino** (@nachoiacovino, nacho.iacovino@gmail.com) — Location parsing (Telegram + WhatsApp)
+<div style="border: 1px solid #2FBF71; border-radius: 8px; padding: 1.2em; background: #0d1117;">
+<h3 style="color: #2FBF71; margin-top: 0;">Green</h3>
+<p>Environmental impact tracking for AI inference. Carbon emissions, water usage, confidence scoring, and compliance exports (GHG Protocol, CDP, TCFD, ISO 14064).</p>
+<p><strong>Status:</strong> Shipped</p>
+<p><a href="green/">Docs &rarr;</a></p>
+</div>
 
-## License
+<div style="border: 1px solid #6C63FF; border-radius: 8px; padding: 1.2em; background: #0d1117;">
+<h3 style="color: #6C63FF; margin-top: 0;">Learning</h3>
+<p>Thompson Sampling bandit that learns which tools and system prompt sections help vs. hurt. Baseline A/B tracking, posterior visualization, and token savings analysis.</p>
+<p><strong>Status:</strong> Shipped (docs coming soon)</p>
+<p><a href="#">Docs &rarr;</a></p>
+</div>
 
-MIT — Free as a lobster in the ocean 🦞
+</div>
+
+## Why a fork?
+
+Upstream OpenClaw is a great gateway. But we wanted to answer questions it doesn't:
+
+- **How much carbon does my AI usage produce?** (Green)
+- **Which tools actually help the agent?** (Learning)
+- **Can the system prompt get smaller without getting worse?** (Learning)
+
+These modules run as **always-on, zero-config layers** inside the gateway. No opt-in, no setup. Data from the first request.
+
+## Quick links
+
+| What | Where |
+|------|-------|
+| Green quick start | [5-minute walkthrough](green/getting-started/quick-start.md) |
+| Green CLI reference | [All `openclaw green` commands](green/guides/cli-reference.md) |
+| Green API reference | [REST endpoints](green/guides/api-reference.md) |
+| Green dashboard | [Chart.js visualizations](green/guides/dashboard.md) |
+| Standards compliance | [GHG Protocol](green/standards/ghg-protocol.md), [CDP](green/standards/cdp-climate.md), [TCFD](green/standards/tcfd.md), [ISO 14064](green/standards/iso-14064.md) |
+| Source | [github.com/Peleke/openclaw](https://github.com/Peleke/openclaw) |
 
 ---
 
-*"We're all just playing with our own prompts."* — An AI, probably high on tokens
+<p align="center" style="color: #555; font-size: 0.9em;">
+  Built by <a href="https://github.com/Peleke">Peleke</a> + Claude.
+  Lobster not included.
+</p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,45 @@
+site_name: OpenClaw
+site_url: https://peleke.github.io/openclaw/
+site_description: Opinionated observability layers for AI agents
+repo_url: https://github.com/Peleke/openclaw
+repo_name: Peleke/openclaw
+docs_dir: docs
+
+theme:
+  name: readthedocs
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Green:
+    - Overview: green/index.md
+    - Getting Started:
+      - Installation: green/getting-started/installation.md
+      - Quick Start: green/getting-started/quick-start.md
+      - Core Concepts: green/getting-started/concepts.md
+    - Guides:
+      - CLI Reference: green/guides/cli-reference.md
+      - Dashboard: green/guides/dashboard.md
+      - Configuration: green/guides/configuration.md
+      - API Reference: green/guides/api-reference.md
+    - Standards:
+      - GHG Protocol: green/standards/ghg-protocol.md
+      - CDP Climate: green/standards/cdp-climate.md
+      - TCFD: green/standards/tcfd.md
+      - ISO 14064: green/standards/iso-14064.md
+      - SBTi ICT: green/standards/sbti-ict.md
+    - Methodology:
+      - Carbon Factors: green/methodology/carbon-factors.md
+      - Confidence Scoring: green/methodology/confidence-scoring.md
+      - Uncertainty Bounds: green/methodology/uncertainty-bounds.md
+      - Regional Grid: green/methodology/regional-grid.md
+    - Reference:
+      - Types: green/reference/types.md
+      - Exports: green/reference/exports.md


### PR DESCRIPTION
## Summary

- Adds a landing page at the docs site root with fork overview, module cards (Green + Learning), and quick links
- Restructures MkDocs config: moves `mkdocs.yml` to repo root, changes `docs_dir` from `green` to `docs` so the site serves from the docs root instead of dropping straight into the Green module
- Updates CI workflow to build from repo root
- Adds `site/` to `.gitignore`

## Before

Visiting https://peleke.github.io/openclaw/ → Green Module index page (no context about the fork)

## After

Visiting https://peleke.github.io/openclaw/ → Landing page with:
- "This is not a fork. It's a claw with opinions."
- Module cards (Green: shipped, Learning: docs coming soon)
- "Why a fork?" section
- Quick links table to all Green docs

Green docs remain at https://peleke.github.io/openclaw/green/

## Test plan

- [ ] `mkdocs build` succeeds from repo root
- [ ] Landing page renders at site root with logo, tagline, module cards
- [ ] Green docs accessible via nav sidebar and direct links
- [ ] CI workflow deploys correctly after merge

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)