### PR TITLE
feat(skills): auto-discover skills-extra dir

### DIFF
--- a/src/agents/skills/workspace.test.ts
+++ b/src/agents/skills/workspace.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SKILLS_EXTRA_DIR, loadWorkspaceSkillEntries } from "./workspace.js";
+
+function writeSkill(dir: string, name: string, description: string): void {
+  const skillDir = path.join(dir, name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+  );
+}
+
+describe("SKILLS_EXTRA_DIR", () => {
+  it("points to skills-extra inside the config directory", () => {
+    expect(SKILLS_EXTRA_DIR).toMatch(/skills-extra$/);
+  });
+});
+
+describe("loadWorkspaceSkillEntries", () => {
+  const tmpDirs: string[] = [];
+
+  function makeTmpDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-skills-test-"));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    for (const dir of tmpDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tmpDirs.length = 0;
+  });
+
+  it("loads skills from config extraDirs", () => {
+    const extraDir = makeTmpDir();
+    const workspaceDir = makeTmpDir();
+    writeSkill(extraDir, "test-extra-skill", "An extra skill");
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: { skills: { load: { extraDirs: [extraDir] } } } as never,
+      bundledSkillsDir: makeTmpDir(), // empty — no bundled skills
+    });
+
+    const names = entries.map((e) => e.skill.name);
+    expect(names).toContain("test-extra-skill");
+  });
+
+  it("loads skills from nested subdirectories in extraDirs", () => {
+    const extraDir = makeTmpDir();
+    const workspaceDir = makeTmpDir();
+    const nestedDir = path.join(extraDir, "vendor");
+    fs.mkdirSync(nestedDir, { recursive: true });
+    writeSkill(nestedDir, "nested-skill", "A nested skill");
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: { skills: { load: { extraDirs: [extraDir] } } } as never,
+      bundledSkillsDir: makeTmpDir(),
+    });
+
+    const names = entries.map((e) => e.skill.name);
+    expect(names).toContain("nested-skill");
+  });
+
+  it("workspace skills override extra skills with same name", () => {
+    const extraDir = makeTmpDir();
+    const workspaceDir = makeTmpDir();
+    writeSkill(extraDir, "my-skill", "Extra version");
+    writeSkill(path.join(workspaceDir, "skills"), "my-skill", "Workspace version");
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: { skills: { load: { extraDirs: [extraDir] } } } as never,
+      bundledSkillsDir: makeTmpDir(),
+    });
+
+    const match = entries.find((e) => e.skill.name === "my-skill");
+    expect(match).toBeDefined();
+    expect(match!.skill.description).toBe("Workspace version");
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -31,6 +31,13 @@ const fsp = fs.promises;
 const skillsLogger = createSubsystemLogger("skills");
 const skillCommandDebugOnce = new Set<string>();
 
+/**
+ * Well-known directory for extra skills synced from external sources
+ * (e.g. the sandbox's sync-skills.sh puts files here).
+ * Auto-discovered when it exists — no config needed.
+ */
+export const SKILLS_EXTRA_DIR = path.join(CONFIG_DIR, "skills-extra");
+
 function debugSkillCommandOnce(
   messageKey: string,
   message: string,
@@ -125,7 +132,9 @@ function loadSkillEntries(
     workspaceDir,
     config: opts?.config,
   });
-  const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
+  // Auto-discover well-known skills-extra dir (populated by sync-skills.sh in sandbox)
+  const wellKnownExtra = fs.existsSync(SKILLS_EXTRA_DIR) ? [SKILLS_EXTRA_DIR] : [];
+  const mergedExtraDirs = [...wellKnownExtra, ...extraDirs, ...pluginSkillDirs];
 
   const bundledSkills = bundledSkillsDir
     ? loadSkills({


### PR DESCRIPTION
## Summary
- Auto-discovers `~/.openclaw/skills-extra/` as a well-known extra skills directory
- This makes the sandbox `sync-skills.sh` pipeline work end-to-end — skills synced there are loaded without manual config
- The dir has lowest precedence (extra tier): config extraDirs, bundled, managed, and workspace skills all override it
- Also supports `skills.load.extraDirs` config for pointing at arbitrary skill repos (e.g. the Anthropic/community skills repo)

## Test plan
- [x] New `workspace.test.ts` with 4 tests: constant check, extraDirs loading, nested subdir discovery, workspace-overrides-extra precedence
- [x] `pnpm build` passes
- [x] `pnpm lint` clean (pre-existing errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)