### PR TITLE
fix(learning): surface silent failures with warn-once logging

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -694,7 +694,7 @@ export async function runEmbeddedPiAgent(
                 if (ownsConn) await conn.close();
               }
             } catch (err) {
-              log.debug(`learning: post-run observation failed: ${String(err)}`);
+              log.warn(`learning: post-run observation failed: ${String(err)}`);
             }
           }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -288,7 +288,7 @@ export async function runEmbeddedAttempt(
           if (ownsConn) await conn.close();
         }
       } catch (err) {
-        log.debug(`learning: pre-run selection failed: ${String(err)}`);
+        log.warn(`learning: pre-run selection failed: ${String(err)}`);
       }
     }
 

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -119,11 +119,15 @@ export async function createGatewayRuntimeState(params: {
     try {
       await sharedConn.init();
       setSharedQortexConnection(sharedConn);
+      const learningCfgStatus = learningCfg?.enabled
+        ? `learning: active, phase=${learningCfg.phase ?? "unknown"}, learner=${learningCfg.learnerName ?? "openclaw"}`
+        : "learning: disabled";
+      params.log.info(`qortex shared connection ready (${learningCfgStatus})`);
     } catch (err) {
       params.log.warn(`qortex shared connection failed to init: ${String(err)}`);
     }
-  } catch {
-    // Qortex module not available; skip
+  } catch (err) {
+    params.log.info(`qortex module not available, skipping shared connection: ${String(err)}`);
   }
 
   // Learning API — uses the shared qortex connection


### PR DESCRIPTION
## Summary

- Add warn-once mechanism to `QortexLearningClient` — first failure per method logs at WARN, subsequent at DEBUG (no log spam, but broken pipeline is now visible)
- Promote pre-run selection and post-run observation catches from `debug` to `warn`
- Add `info` log on successful qortex shared connection showing learning config status
- Make outer qortex module catch visible instead of silent `catch {}`

## Context

The learning pipeline (select/observe via qortex) was swallowing every failure at debug level. A completely broken pipeline was invisible in gateway logs — you'd have to know to look at debug output to see anything was wrong.

After this change, gateway startup shows:
```
qortex shared connection ready (learning: active, phase=active, learner=openclaw)
```

And failures surface at WARN:
```
[learning] qortex learning select failed, falling back to all: ...
```

## Companion PR

- Peleke/openclaw-sandbox — OTEL env vars, firewall rules, learning config injection

## Test plan

- [x] Gateway startup log shows learning config status
- [x] First learning failure surfaces at WARN level
- [x] Subsequent failures for same method drop to DEBUG (no spam)
- [x] `posteriors()`, `metrics()`, `sessionStart()`, `sessionEnd()` remain at DEBUG (read-only/bookkeeping)
- [x] Verified end-to-end: selections + observations visible in gateway logs and Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)