### PR TITLE
docs: sync learning docs with pipeline fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Docs: https://docs.openclaw.ai
 
+## 2026.2.12
+
+### Fixes
+- Learning: forward `minPulls` exploration floor to qortex backend so underexplored arms are always included during active selection. (#79)
+- Learning: inject excluded-tools guidance into the system prompt when tools are excluded by the bandit, so the model can explain unavailability instead of producing empty responses. (#79)
+- Learning: normalize qortex Arm objects to string IDs at the client boundary, fixing selection mapping when qortex returns `{id, metadata, token_cost}` objects. (#82)
+
 ## 2026.1.29
 Status: stable.
 

--- a/docs/learning/getting-started/concepts.md
+++ b/docs/learning/getting-started/concepts.md
@@ -112,9 +112,13 @@ This is the default and is safe to leave on indefinitely.
 In active mode, the learning layer **optimizes prompt composition**:
 
 - Thompson Sampling selects arms within the token budget
-- Seed arms and underexplored arms are always included
+- Seed arms and underexplored arms (fewer than `minPulls` observations) are always included
 - Baseline runs (configurable rate) use the full prompt for comparison
 - Posteriors are updated after each run
+
+#### Excluded-Tools Guidance
+
+When Thompson Sampling excludes tools from a run, the system injects guidance into the model's system prompt listing which tools are currently unavailable. This means the model can explain to users when a requested capability is temporarily excluded, rather than silently producing an empty or confused response.
 
 **When to switch to active:**
 

--- a/docs/learning/guides/configuration.md
+++ b/docs/learning/guides/configuration.md
@@ -104,6 +104,8 @@ Fraction of runs that use the full prompt (all arms included) for counterfactual
 
 Arms with fewer than this many observations are always included (never excluded by Thompson Sampling). This ensures every arm gets enough data before the bandit can decide to drop it.
 
+This value is forwarded to the qortex backend as an exploration floor. Even when the token budget is tight, arms below the `minPulls` threshold are guaranteed inclusion.
+
 ### `decayHalfLifeDays` (future)
 
 | | |

--- a/docs/learning/theory/reward-model.md
+++ b/docs/learning/theory/reward-model.md
@@ -24,6 +24,8 @@ After each run, the learning layer checks whether each included arm was actually
 
 Only included arms receive updates. Excluded arms have no observed outcome, so their posteriors remain unchanged. This is a key property — the system doesn't penalize arms it chose not to include.
 
+When tools are excluded, the system injects guidance into the model's system prompt listing which tools are unavailable. This allows the model to gracefully explain to users that a capability is temporarily excluded and suggest alternatives, rather than silently producing an empty response.
+
 ## Initial Priors
 
 Priors encode domain knowledge about how likely an arm is to be useful before any data is observed.


### PR DESCRIPTION
## Summary
- Add changelog entries for the three learning pipeline fixes (#79, #82)
- Document excluded-tools guidance behavior in concepts and reward model docs
- Note `minPulls` forwarding to qortex backend in configuration docs

## Test plan
- [ ] Verify mkdocs builds cleanly (`mkdocs build`)
- [ ] Review rendered docs for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)