### PR TITLE
docs: update qortex transport docs for REST client migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.25
 
 ### Features
-- Qortex: support MCP Streamable HTTP transport for gateway↔qortex connection, replacing stdio subprocess model. Set `memorySearch.qortex.transport: "http"` with `memorySearch.qortex.http.baseUrl` pointing at the qortex MCP service endpoint.
-- Qortex: `QortexHttpConnection` uses `StreamableHTTPClientTransport` from `@modelcontextprotocol/sdk` for persistent HTTP-based MCP communication.
+- Qortex: support plain REST HTTP transport for gateway↔qortex connection via `QortexRestConnection`, replacing stdio subprocess model. Set `memorySearch.qortex.transport: "http"` with `memorySearch.qortex.http.baseUrl` pointing at the qortex REST API base URL.
+- Qortex: `QortexRestConnection` uses `fetch()` for direct HTTP calls to qortex REST API endpoints (e.g., `POST /v1/query`, `POST /v1/ingest/message`). No MCP protocol layer in HTTP mode.
 
 ## 2026.2.16
 


### PR DESCRIPTION
## Summary

- Update `docs/qortex/integration.md` to reflect that `QortexHttpConnection` (MCP-over-HTTP via `StreamableHTTPClientTransport`) has been replaced by `QortexRestConnection` (plain REST via `fetch()`)
- Update architecture diagrams, config examples, and endpoint references (port 8401/mcp -> port 8400, REST endpoints like `POST /v1/query`)
- Update `CHANGELOG.md` entries for the 2026.2.25 release to describe the REST transport accurately
- No new documentation created; only existing references updated

## Changes

| File | What changed |
|------|-------------|
| `docs/qortex/integration.md` | HTTP transport section rewritten for `QortexRestConnection`; architecture diagram updated; config table and examples updated; `qortex-mcp.service` -> `qortex.service`; `qortex_mcp_enabled` -> `qortex_serve_enabled`; section header from "MCP tools available" to "Available operations" |
| `CHANGELOG.md` | 2026.2.25 feature entries updated to reference `QortexRestConnection` and `fetch()` instead of `QortexHttpConnection` and `StreamableHTTPClientTransport` |

## Test plan

- [ ] Verify `docs/qortex/integration.md` renders correctly on GitHub
- [ ] Confirm no stale MCP-over-HTTP transport references remain in docs (stdio MCP references are intentionally preserved -- that transport still uses MCP)
- [ ] Confirm CHANGELOG entries are accurate

Generated with [Claude Code](https://claude.com/claude-code)