### PR TITLE
feat(cadence): runlist responder — morning ping + nightly recap

### DIFF
--- a/src/cadence/config.ts
+++ b/src/cadence/config.ts
@@ -72,6 +72,18 @@ export interface CadenceP1Config {
     timezone: string;
   };
 
+  /** Runlist responder settings (morning ping + nightly recap) */
+  runlist?: {
+    /** Enable the runlist responder (default: false) */
+    enabled: boolean;
+    /** Morning ping time in HH:MM format (default: "07:30") */
+    morningTime?: string;
+    /** Nightly recap time in HH:MM format (default: "22:00") */
+    nightlyTime?: string;
+    /** Directory within vault containing runlist files (default: "Runlist") */
+    runlistDir?: string;
+  };
+
   /** GitHub Watcher settings (nightly repo scan + synthesis) */
   githubWatcher?: {
     /** Enable the GitHub watcher (default: false) */
@@ -153,6 +165,7 @@ export async function loadCadenceConfig(): Promise<CadenceP1Config> {
       digest: { ...DEFAULT_CONFIG.digest, ...parsed.digest },
       schedule: { ...DEFAULT_CONFIG.schedule, ...parsed.schedule },
       pillars: parsed.pillars ?? DEFAULT_CONFIG.pillars,
+      runlist: parsed.runlist,
       githubWatcher: parsed.githubWatcher,
     };
   } catch {
@@ -222,6 +235,22 @@ export function getScheduledJobs(config: CadenceP1Config): Array<{
         tz: config.schedule.timezone,
       });
     }
+  }
+
+  // Runlist responder has its own enabled flag, independent of schedule.enabled
+  if (config.runlist?.enabled) {
+    jobs.push({
+      id: "runlist-morning",
+      name: "Runlist Morning Ping",
+      expr: timeToCron(config.runlist.morningTime ?? "07:30"),
+      tz: config.schedule.timezone,
+    });
+    jobs.push({
+      id: "runlist-nightly",
+      name: "Runlist Nightly Recap",
+      expr: timeToCron(config.runlist.nightlyTime ?? "22:00"),
+      tz: config.schedule.timezone,
+    });
   }
 
   // GitHub Watcher has its own enabled flag, independent of schedule.enabled

--- a/src/cadence/index.ts
+++ b/src/cadence/index.ts
@@ -38,6 +38,14 @@ export {
 export { createInsightExtractorResponder } from "./responders/insight-extractor/index.js";
 export { createInsightDigestResponder } from "./responders/insight-digest/index.js";
 export { createTelegramNotifierResponder } from "./responders/telegram-notifier.js";
+export {
+  createLinWheelPublisherResponder,
+  type LinWheelPublisherOptions,
+} from "./responders/linwheel-publisher/index.js";
+export {
+  createGitHubWatcherResponder,
+  type GitHubWatcherOptions,
+} from "./responders/github-watcher/index.js";
 
 // LLM
 export { createOpenClawLLMAdapter, createMockLLMProvider } from "./llm/openclaw-adapter.js";

--- a/src/cadence/responders/github-watcher/github-client.test.ts
+++ b/src/cadence/responders/github-watcher/github-client.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createFsFileWriter } from "./github-client.js";
+
+// Only test createFsFileWriter (pure fs operations).
+// createGhCliClient tests would require mocking execFile which is
+// better covered by integration tests with the real CLI.
+
+describe("createFsFileWriter", () => {
+  it("exists() returns false for non-existent files", async () => {
+    const writer = createFsFileWriter();
+    const result = await writer.exists("/tmp/__does_not_exist_" + Date.now() + ".md");
+    expect(result).toBe(false);
+  });
+
+  it("write() creates a file and exists() detects it", async () => {
+    const writer = createFsFileWriter();
+    const testPath = `/tmp/__gh_watcher_test_${Date.now()}.md`;
+
+    await writer.write(testPath, "hello world");
+    const exists = await writer.exists(testPath);
+    expect(exists).toBe(true);
+
+    // Clean up
+    const { unlink } = await import("node:fs/promises");
+    await unlink(testPath);
+  });
+
+  it("write() creates intermediate directories", async () => {
+    const writer = createFsFileWriter();
+    const testDir = `/tmp/__gh_watcher_nested_${Date.now()}`;
+    const testPath = `${testDir}/sub/file.md`;
+
+    await writer.write(testPath, "nested content");
+    const exists = await writer.exists(testPath);
+    expect(exists).toBe(true);
+
+    // Clean up
+    const { rm } = await import("node:fs/promises");
+    await rm(testDir, { recursive: true });
+  });
+});

--- a/src/cadence/responders/github-watcher/github-client.ts
+++ b/src/cadence/responders/github-watcher/github-client.ts
@@ -1,0 +1,174 @@
+/**
+ * GitHub API client wrapping `gh api` CLI commands.
+ *
+ * Uses `execFile` for safety (no shell injection) and relies on
+ * GH_TOKEN being set in the environment for authentication.
+ */
+
+import { execFile } from "node:child_process";
+import { stat, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { GitHubClient, GitHubRepo, GitHubPR, BuildlogEntry, FileWriter } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Call `gh api` with the given path and return parsed JSON.
+ */
+async function ghApi<T>(apiPath: string): Promise<T> {
+  const { stdout } = await execFileAsync("gh", ["api", apiPath, "--paginate"], {
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return JSON.parse(stdout) as T;
+}
+
+/**
+ * Call `gh api` for a search endpoint (returns { items: T[] }).
+ */
+async function ghSearchApi<T>(apiPath: string): Promise<T[]> {
+  const { stdout } = await execFileAsync("gh", ["api", apiPath], {
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const result = JSON.parse(stdout) as { items: T[] };
+  return result.items ?? [];
+}
+
+interface GHRepoResponse {
+  name: string;
+  full_name: string;
+  archived: boolean;
+  fork: boolean;
+  pushed_at: string;
+}
+
+interface GHSearchPRItem {
+  number: number;
+  title: string;
+  html_url: string;
+  body: string | null;
+  pull_request?: { merged_at?: string | null };
+  created_at: string;
+}
+
+interface GHPRResponse {
+  number: number;
+  title: string;
+  html_url: string;
+  body: string | null;
+  created_at: string;
+}
+
+interface GHContentItem {
+  name: string;
+  type: string;
+  download_url: string | null;
+  content?: string;
+  encoding?: string;
+}
+
+/**
+ * Create a GitHubClient backed by `gh api` CLI.
+ */
+export function createGhCliClient(): GitHubClient {
+  return {
+    async listRepos(owner: string): Promise<GitHubRepo[]> {
+      const repos = await ghApi<GHRepoResponse[]>(
+        `/users/${encodeURIComponent(owner)}/repos?per_page=100&type=owner&sort=pushed`,
+      );
+      return repos
+        .filter((r) => !r.archived && !r.fork)
+        .map((r) => ({
+          name: r.name,
+          fullName: r.full_name,
+          archived: r.archived,
+          fork: r.fork,
+          pushedAt: r.pushed_at,
+        }));
+    },
+
+    async getMergedPRsForDate(repo: string, date: string): Promise<GitHubPR[]> {
+      const q = encodeURIComponent(`repo:${repo} is:pr is:merged merged:${date}`);
+      const items = await ghSearchApi<GHSearchPRItem>(`/search/issues?q=${q}&per_page=30`);
+      return items.map((item) => ({
+        number: item.number,
+        title: item.title,
+        url: item.html_url,
+        body: (item.body ?? "").slice(0, 200),
+        mergedAt: item.pull_request?.merged_at ?? undefined,
+        createdAt: item.created_at,
+      }));
+    },
+
+    async getOpenPRs(repo: string): Promise<GitHubPR[]> {
+      const prs = await ghApi<GHPRResponse[]>(`/repos/${repo}/pulls?state=open&per_page=30`);
+      return prs.map((pr) => ({
+        number: pr.number,
+        title: pr.title,
+        url: pr.html_url,
+        body: (pr.body ?? "").slice(0, 200),
+        createdAt: pr.created_at,
+      }));
+    },
+
+    async hasBuildlogDir(repo: string): Promise<boolean> {
+      try {
+        await ghApi<GHContentItem[]>(`/repos/${repo}/contents/buildlog`);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    async getRecentBuildlogEntries(repo: string, limit: number): Promise<BuildlogEntry[]> {
+      try {
+        const items = await ghApi<GHContentItem[]>(`/repos/${repo}/contents/buildlog`);
+        const mdFiles = items
+          .filter((i) => i.type === "file" && i.name.endsWith(".md"))
+          .sort((a, b) => b.name.localeCompare(a.name))
+          .slice(0, limit);
+
+        const entries: BuildlogEntry[] = [];
+        for (const file of mdFiles) {
+          try {
+            const detail = await ghApi<GHContentItem>(
+              `/repos/${repo}/contents/buildlog/${encodeURIComponent(file.name)}`,
+            );
+            const content =
+              detail.encoding === "base64" && detail.content
+                ? Buffer.from(detail.content, "base64").toString("utf-8").slice(0, 500)
+                : "";
+            entries.push({ name: file.name, content });
+          } catch {
+            // Skip individual file failures
+          }
+        }
+
+        return entries;
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+/**
+ * Create a FileWriter backed by the filesystem.
+ */
+export function createFsFileWriter(): FileWriter {
+  return {
+    async exists(filePath: string): Promise<boolean> {
+      try {
+        await stat(filePath);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    async write(filePath: string, content: string): Promise<void> {
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, content, "utf-8");
+    },
+  };
+}

--- a/src/cadence/responders/github-watcher/index.test.ts
+++ b/src/cadence/responders/github-watcher/index.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createSignalBus, type SignalBus } from "@peleke.s/cadence";
+import type { OpenClawSignal } from "../../signals.js";
+import type { LLMProvider, ChatMessage, ChatResponse } from "../../llm/types.js";
+import type {
+  GitHubClient,
+  GitHubRepo,
+  GitHubPR,
+  BuildlogEntry,
+  FileWriter,
+  WatcherClock,
+} from "./types.js";
+import { createGitHubWatcherResponder } from "./index.js";
+
+// --- Mocks ---
+
+function createMockGhClient(overrides: Partial<GitHubClient> = {}): GitHubClient {
+  return {
+    listRepos: vi.fn<[string], Promise<GitHubRepo[]>>().mockResolvedValue([
+      {
+        name: "openclaw",
+        fullName: "Peleke/openclaw",
+        archived: false,
+        fork: false,
+        pushedAt: "2026-02-26T10:00:00Z",
+      },
+      {
+        name: "linwheel",
+        fullName: "Peleke/linwheel",
+        archived: false,
+        fork: false,
+        pushedAt: "2026-02-26T08:00:00Z",
+      },
+    ]),
+    getMergedPRsForDate: vi.fn<[string, string], Promise<GitHubPR[]>>().mockResolvedValue([]),
+    getOpenPRs: vi.fn<[string, string], Promise<GitHubPR[]>>().mockResolvedValue([]),
+    hasBuildlogDir: vi.fn<[string], Promise<boolean>>().mockResolvedValue(false),
+    getRecentBuildlogEntries: vi
+      .fn<[string, number], Promise<BuildlogEntry[]>>()
+      .mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function createMockLlm(
+  text = "# Today's Engineering Log\n\nWe shipped some great features today across multiple repos. Lots of progress.",
+): LLMProvider {
+  return {
+    name: "mock-llm",
+    chat: vi.fn<[ChatMessage[]], Promise<ChatResponse>>().mockResolvedValue({
+      text,
+      model: "test-model",
+    }),
+  };
+}
+
+function createMockWriter(existsResult = false): FileWriter {
+  return {
+    exists: vi.fn<[string], Promise<boolean>>().mockResolvedValue(existsResult),
+    write: vi.fn<[string, string], Promise<void>>().mockResolvedValue(undefined),
+  };
+}
+
+function createMockClock(date = "2026-02-26"): WatcherClock {
+  return { today: () => date };
+}
+
+function cronSignal(jobId: string) {
+  return {
+    type: "cadence.cron.fired" as const,
+    id: "test-cron-signal",
+    ts: Date.now(),
+    payload: {
+      jobId,
+      jobName: "GitHub Watcher",
+      expr: "0 21 * * *",
+      firedAt: Date.now(),
+    },
+  };
+}
+
+// --- Tests ---
+
+describe("createGitHubWatcherResponder", () => {
+  let bus: SignalBus<OpenClawSignal>;
+
+  beforeEach(() => {
+    bus = createSignalBus<OpenClawSignal>();
+  });
+
+  it("has correct name and description", () => {
+    const responder = createGitHubWatcherResponder({
+      llm: createMockLlm(),
+      vaultPath: "/vault",
+    });
+    expect(responder.name).toBe("github-watcher");
+    expect(responder.description).toContain("GitHub");
+  });
+
+  it("ignores cron signals with non-matching jobId", async () => {
+    const ghClient = createMockGhClient();
+    const responder = createGitHubWatcherResponder({
+      llm: createMockLlm(),
+      ghClient,
+      vaultPath: "/vault",
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("nightly-digest"));
+
+    expect(ghClient.listRepos).not.toHaveBeenCalled();
+  });
+
+  it("triggers on matching jobId", async () => {
+    const ghClient = createMockGhClient();
+    const writer = createMockWriter();
+    const responder = createGitHubWatcherResponder({
+      llm: createMockLlm(),
+      ghClient,
+      writer,
+      clock: createMockClock(),
+      vaultPath: "/vault",
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    expect(ghClient.listRepos).toHaveBeenCalledWith("Peleke");
+  });
+
+  it("skips if synthesis file already exists (dedup)", async () => {
+    const ghClient = createMockGhClient();
+    const writer = createMockWriter(true); // exists returns true
+    const responder = createGitHubWatcherResponder({
+      llm: createMockLlm(),
+      ghClient,
+      writer,
+      clock: createMockClock(),
+      vaultPath: "/vault",
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    expect(ghClient.listRepos).not.toHaveBeenCalled();
+    expect(writer.write).not.toHaveBeenCalled();
+  });
+
+  it("excludes configured repos", async () => {
+    const ghClient = createMockGhClient();
+    const writer = createMockWriter();
+    const responder = createGitHubWatcherResponder({
+      llm: createMockLlm(),
+      ghClient,
+      writer,
+      clock: createMockClock(),
+      vaultPath: "/vault",
+      config: { excludeRepos: ["linwheel"] },
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    // getMergedPRsForDate should only be called for openclaw, not linwheel
+    const calls = (ghClient.getMergedPRsForDate as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.some((c: string[]) => c[0] === "Peleke/linwheel")).toBe(false);
+    expect(calls.some((c: string[]) => c[0] === "Peleke/openclaw")).toBe(true);
+  });
+
+  it("skips synthesis when no activity found", async () => {
+    const llm = createMockLlm();
+    const writer = createMockWriter();
+    const responder = createGitHubWatcherResponder({
+      llm,
+      ghClient: createMockGhClient(), // all repos return empty PRs
+      writer,
+      clock: createMockClock(),
+      vaultPath: "/vault",
+    });
+
+    const emitted: OpenClawSignal[] = [];
+    bus.on("github.scan.completed", (s) => {
+      emitted.push(s);
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    // Scan signal emitted but no write
+    expect(emitted.length).toBe(1);
+    expect(llm.chat).not.toHaveBeenCalled();
+    expect(writer.write).not.toHaveBeenCalled();
+  });
+
+  it("runs full pipeline: scan → synthesize → write", async () => {
+    const ghClient = createMockGhClient({
+      getMergedPRsForDate: vi.fn().mockImplementation(async (repo: string) => {
+        if (repo === "Peleke/openclaw") {
+          return [
+            {
+              number: 70,
+              title: "feat: cadence wiring",
+              url: "https://github.com/Peleke/openclaw/pull/70",
+              body: "Wire cadence into gateway",
+              createdAt: "2026-02-26T10:00:00Z",
+              mergedAt: "2026-02-26T15:00:00Z",
+            },
+          ];
+        }
+        return [];
+      }),
+    });
+
+    const llm = createMockLlm(
+      "# Engineering Log\n\nToday I shipped cadence wiring (PR #70) in openclaw. This connects the signal bus to the gateway for ambient content processing.",
+    );
+    const writer = createMockWriter();
+    const clock = createMockClock("2026-02-26");
+
+    const responder = createGitHubWatcherResponder({
+      llm,
+      ghClient,
+      writer,
+      clock,
+      vaultPath: "/vault",
+    });
+
+    const scanSignals: OpenClawSignal[] = [];
+    const synthSignals: OpenClawSignal[] = [];
+    bus.on("github.scan.completed", (s) => {
+      scanSignals.push(s);
+    });
+    bus.on("github.synthesis.written", (s) => {
+      synthSignals.push(s);
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    // Scan signal
+    expect(scanSignals.length).toBe(1);
+    expect(scanSignals[0].payload.reposScanned).toBe(2);
+    expect(scanSignals[0].payload.reposWithActivity).toBe(1);
+
+    // LLM called
+    expect(llm.chat).toHaveBeenCalledOnce();
+
+    // File written with ::linkedin prefix
+    expect(writer.write).toHaveBeenCalledOnce();
+    const [writePath, writeContent] = (writer.write as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(writePath).toContain("2026-02-26-github-synthesis.md");
+    expect(writePath).toContain("Buildlog");
+    expect(writeContent).toMatch(/^::linkedin\n\n/);
+
+    // Synthesis signal
+    expect(synthSignals.length).toBe(1);
+    expect(synthSignals[0].payload.linkedinReady).toBe(true);
+    expect(synthSignals[0].payload.reposIncluded).toBe(1);
+    expect(synthSignals[0].payload.totalPRs).toBe(1);
+  });
+
+  it("emits error signal on total failure", async () => {
+    const ghClient = createMockGhClient({
+      listRepos: vi.fn().mockRejectedValue(new Error("API rate limit")),
+    });
+    const writer = createMockWriter();
+
+    const responder = createGitHubWatcherResponder({
+      llm: createMockLlm(),
+      ghClient,
+      writer,
+      clock: createMockClock(),
+      vaultPath: "/vault",
+    });
+
+    const synthSignals: OpenClawSignal[] = [];
+    bus.on("github.synthesis.written", (s) => {
+      synthSignals.push(s);
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    expect(synthSignals.length).toBe(1);
+    expect(synthSignals[0].payload.error).toContain("API rate limit");
+    expect(synthSignals[0].payload.linkedinReady).toBe(false);
+  });
+
+  it("handles per-repo errors gracefully", async () => {
+    const ghClient = createMockGhClient({
+      getMergedPRsForDate: vi.fn().mockImplementation(async (repo: string) => {
+        if (repo === "Peleke/openclaw") {
+          throw new Error("timeout");
+        }
+        return [
+          {
+            number: 5,
+            title: "Fix bug",
+            url: "https://github.com/Peleke/linwheel/pull/5",
+            body: "",
+            createdAt: "2026-02-26T10:00:00Z",
+            mergedAt: "2026-02-26T15:00:00Z",
+          },
+        ];
+      }),
+    });
+
+    const writer = createMockWriter();
+    const llm = createMockLlm(
+      "# Engineering Log\n\nFixed a bug in linwheel today. Good progress on the publisher pipeline.",
+    );
+
+    const responder = createGitHubWatcherResponder({
+      llm,
+      ghClient,
+      writer,
+      clock: createMockClock(),
+      vaultPath: "/vault",
+    });
+
+    const scanSignals: OpenClawSignal[] = [];
+    bus.on("github.scan.completed", (s) => {
+      scanSignals.push(s);
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    // Should still emit scan signal with errors
+    expect(scanSignals.length).toBe(1);
+    expect(scanSignals[0].payload.errors.length).toBe(1);
+    expect(scanSignals[0].payload.errors[0].repo).toBe("Peleke/openclaw");
+
+    // Should still synthesize the successful repo
+    expect(llm.chat).toHaveBeenCalled();
+    expect(writer.write).toHaveBeenCalled();
+  });
+
+  it("emits synthesis signal with error when LLM returns too-short response", async () => {
+    const ghClient = createMockGhClient({
+      getMergedPRsForDate: vi.fn().mockResolvedValue([
+        {
+          number: 1,
+          title: "PR",
+          url: "https://github.com/x/1",
+          body: "",
+          createdAt: "2026-02-26T10:00:00Z",
+          mergedAt: "2026-02-26T15:00:00Z",
+        },
+      ]),
+    });
+    const llm = createMockLlm("Too short"); // under 50 chars
+    const writer = createMockWriter();
+
+    const responder = createGitHubWatcherResponder({
+      llm,
+      ghClient,
+      writer,
+      clock: createMockClock(),
+      vaultPath: "/vault",
+    });
+
+    const synthSignals: OpenClawSignal[] = [];
+    bus.on("github.synthesis.written", (s) => {
+      synthSignals.push(s);
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    expect(writer.write).not.toHaveBeenCalled();
+    expect(synthSignals.length).toBe(1);
+    expect(synthSignals[0].payload.error).toContain("too short");
+    expect(synthSignals[0].payload.linkedinReady).toBe(false);
+  });
+
+  it("reads buildlog entries when directory exists", async () => {
+    const ghClient = createMockGhClient({
+      hasBuildlogDir: vi.fn().mockResolvedValue(true),
+      getRecentBuildlogEntries: vi
+        .fn()
+        .mockResolvedValue([{ name: "2026-02-26.md", content: "Shipped overlay fix" }]),
+      getMergedPRsForDate: vi.fn().mockResolvedValue([
+        {
+          number: 1,
+          title: "PR",
+          url: "https://github.com/x/1",
+          body: "",
+          createdAt: "2026-02-26T10:00:00Z",
+          mergedAt: "2026-02-26T15:00:00Z",
+        },
+      ]),
+    });
+
+    const llm = createMockLlm(
+      "# Engineering Log\n\nShipped overlay fix today. Major progress on the infrastructure.",
+    );
+    const writer = createMockWriter();
+
+    const responder = createGitHubWatcherResponder({
+      llm,
+      ghClient,
+      writer,
+      clock: createMockClock(),
+      vaultPath: "/vault",
+    });
+
+    responder.register(bus);
+    await bus.emit(cronSignal("github-watcher"));
+
+    // LLM prompt should include buildlog content
+    const llmCalls = (llm.chat as ReturnType<typeof vi.fn>).mock.calls;
+    const userPrompt = llmCalls[0][0][1].content;
+    expect(userPrompt).toContain("Shipped overlay fix");
+  });
+
+  it("supports custom cronTriggerJobIds", async () => {
+    const ghClient = createMockGhClient();
+    const responder = createGitHubWatcherResponder({
+      llm: createMockLlm(),
+      ghClient,
+      writer: createMockWriter(),
+      clock: createMockClock(),
+      vaultPath: "/vault",
+      cronTriggerJobIds: ["custom-github-scan"],
+    });
+
+    responder.register(bus);
+
+    // Default job ID should NOT trigger
+    await bus.emit(cronSignal("github-watcher"));
+    expect(ghClient.listRepos).not.toHaveBeenCalled();
+
+    // Custom job ID should trigger
+    await bus.emit(cronSignal("custom-github-scan"));
+    expect(ghClient.listRepos).toHaveBeenCalled();
+  });
+
+  it("cleanup unsubscribes from cron signal", async () => {
+    const ghClient = createMockGhClient();
+    const responder = createGitHubWatcherResponder({
+      llm: createMockLlm(),
+      ghClient,
+      writer: createMockWriter(),
+      clock: createMockClock(),
+      vaultPath: "/vault",
+    });
+
+    const unsub = responder.register(bus);
+    unsub();
+
+    await bus.emit(cronSignal("github-watcher"));
+    expect(ghClient.listRepos).not.toHaveBeenCalled();
+  });
+});

--- a/src/cadence/responders/github-watcher/index.ts
+++ b/src/cadence/responders/github-watcher/index.ts
@@ -1,0 +1,295 @@
+/**
+ * GitHub Watcher responder.
+ *
+ * Subscribes to cadence.cron.fired signals (filtered by jobId),
+ * scans all repos for the configured owner, collects PRs and
+ * buildlog entries, synthesizes via LLM, and writes a ::linkedin
+ * tagged note to the vault for downstream processing.
+ */
+
+import crypto from "node:crypto";
+import path from "node:path";
+import type { SignalBus } from "@peleke.s/cadence";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { LLMProvider } from "../../llm/types.js";
+import type { OpenClawSignal } from "../../signals.js";
+import type { CadenceP1Config } from "../../config.js";
+import type { Responder } from "../index.js";
+import {
+  DEFAULT_GITHUB_WATCHER_CONFIG,
+  type GitHubWatcherConfig,
+  type GitHubClient,
+  type FileWriter,
+  type WatcherClock,
+  type RepoScanResult,
+} from "./types.js";
+import { createGhCliClient, createFsFileWriter } from "./github-client.js";
+import {
+  buildSynthesisSystemPrompt,
+  buildSynthesisUserPrompt,
+  parseSynthesisResponse,
+} from "./prompts.js";
+
+const log = createSubsystemLogger("cadence").child("github-watcher");
+
+export interface GitHubWatcherOptions {
+  /** LLM provider for synthesis */
+  llm: LLMProvider;
+
+  /** GitHub API client (defaults to gh CLI wrapper) */
+  ghClient?: GitHubClient;
+
+  /** File writer (defaults to filesystem) */
+  writer?: FileWriter;
+
+  /** Clock for testability (defaults to real date) */
+  clock?: WatcherClock;
+
+  /** Partial config overrides */
+  config?: Partial<GitHubWatcherConfig>;
+
+  /** Vault path for output (from cadence config) */
+  vaultPath: string;
+
+  /** Content pillars for synthesis context */
+  pillars?: CadenceP1Config["pillars"];
+
+  /** Cron job IDs that trigger this responder (default: ["github-watcher"]) */
+  cronTriggerJobIds?: string[];
+}
+
+/**
+ * Default clock using real dates.
+ */
+function createRealClock(): WatcherClock {
+  return {
+    today() {
+      return new Date().toISOString().split("T")[0];
+    },
+  };
+}
+
+/**
+ * Scan a single repo for activity.
+ */
+async function scanRepo(
+  ghClient: GitHubClient,
+  repo: { name: string; fullName: string },
+  date: string,
+  maxBuildlogEntries: number,
+): Promise<RepoScanResult> {
+  const result: RepoScanResult = {
+    name: repo.name,
+    fullName: repo.fullName,
+    mergedPRs: [],
+    openPRs: [],
+    buildlogEntries: [],
+  };
+
+  // Merged PRs for today
+  const mergedPRs = await ghClient.getMergedPRsForDate(repo.fullName, date);
+  result.mergedPRs = mergedPRs.map((pr) => ({
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+  }));
+
+  // Open PRs
+  const openPRs = await ghClient.getOpenPRs(repo.fullName);
+  result.openPRs = openPRs.map((pr) => ({
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+  }));
+
+  // Buildlog entries
+  const hasBuildlog = await ghClient.hasBuildlogDir(repo.fullName);
+  if (hasBuildlog) {
+    result.buildlogEntries = await ghClient.getRecentBuildlogEntries(
+      repo.fullName,
+      maxBuildlogEntries,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Create the GitHub watcher responder.
+ */
+export function createGitHubWatcherResponder(options: GitHubWatcherOptions): Responder {
+  const config: GitHubWatcherConfig = {
+    ...DEFAULT_GITHUB_WATCHER_CONFIG,
+    ...options.config,
+  };
+  const ghClient = options.ghClient ?? createGhCliClient();
+  const writer = options.writer ?? createFsFileWriter();
+  const clock = options.clock ?? createRealClock();
+  const cronTriggerJobIds = options.cronTriggerJobIds ?? ["github-watcher"];
+
+  return {
+    name: "github-watcher",
+    description: "Scans GitHub repos nightly, synthesizes activity into ::linkedin vault notes",
+
+    register(bus: SignalBus<OpenClawSignal>): () => void {
+      log.info("GitHub watcher responder starting", {
+        owner: config.owner,
+        scanTime: config.scanTime,
+        excludeRepos: config.excludeRepos,
+        cronTriggerJobIds,
+      });
+
+      const unsubCron = bus.on("cadence.cron.fired", async (signal) => {
+        const { jobId } = signal.payload;
+
+        if (!cronTriggerJobIds.includes(jobId)) {
+          return;
+        }
+
+        const scanDate = clock.today();
+        const outputFilename = `${scanDate}-github-synthesis.md`;
+        const outputPath = path.join(options.vaultPath, config.outputDir, outputFilename);
+
+        log.info(`GitHub watcher triggered for ${scanDate}`);
+
+        // Dedup: skip if today's synthesis already exists
+        if (await writer.exists(outputPath)) {
+          log.info(`Synthesis already exists for ${scanDate}, skipping`);
+          return;
+        }
+
+        try {
+          // 1. List repos
+          const allRepos = await ghClient.listRepos(config.owner);
+          const repos = allRepos.filter((r) => !config.excludeRepos.includes(r.name));
+
+          log.info(`Scanning ${repos.length} repos for ${config.owner}`);
+
+          // 2. Scan each repo (sequential to respect rate limits)
+          const scanResults: RepoScanResult[] = [];
+          const errors: Array<{ repo: string; error: string }> = [];
+
+          for (const repo of repos) {
+            try {
+              const result = await scanRepo(ghClient, repo, scanDate, config.maxBuildlogEntries);
+              scanResults.push(result);
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              errors.push({ repo: repo.fullName, error: msg });
+              log.warn(`Failed to scan ${repo.fullName}: ${msg}`);
+            }
+          }
+
+          // 3. Emit scan completed signal
+          const reposWithActivity = scanResults.filter(
+            (r) => r.mergedPRs.length > 0 || r.openPRs.length > 0,
+          );
+          const reposWithBuildlog = scanResults.filter((r) => r.buildlogEntries.length > 0);
+
+          await bus.emit({
+            type: "github.scan.completed",
+            id: crypto.randomUUID(),
+            ts: Date.now(),
+            payload: {
+              scanDate,
+              reposScanned: repos.length,
+              reposWithActivity: reposWithActivity.length,
+              reposWithBuildlog: reposWithBuildlog.length,
+              repos: scanResults,
+              errors,
+            },
+          });
+
+          // 4. Skip synthesis if no activity
+          const activeRepos = scanResults.filter(
+            (r) => r.mergedPRs.length > 0 || r.openPRs.length > 0 || r.buildlogEntries.length > 0,
+          );
+
+          if (activeRepos.length === 0) {
+            log.info(`No activity found for ${scanDate}, skipping synthesis`);
+            return;
+          }
+
+          // 5. LLM synthesis
+          const systemPrompt = buildSynthesisSystemPrompt();
+          const userPrompt = buildSynthesisUserPrompt(activeRepos, scanDate);
+
+          const response = await options.llm.chat([
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userPrompt },
+          ]);
+
+          const synthesis = parseSynthesisResponse(response.text);
+          if (!synthesis) {
+            log.warn("LLM returned insufficient synthesis, skipping write");
+            await bus.emit({
+              type: "github.synthesis.written",
+              id: crypto.randomUUID(),
+              ts: Date.now(),
+              payload: {
+                outputPath,
+                scanDate,
+                reposIncluded: activeRepos.length,
+                totalPRs: activeRepos.reduce(
+                  (n, r) => n + r.mergedPRs.length + r.openPRs.length,
+                  0,
+                ),
+                linkedinReady: false,
+                error: "LLM synthesis too short",
+              },
+            });
+            return;
+          }
+
+          // 6. Write to vault with ::linkedin tag
+          const totalPRs = activeRepos.reduce(
+            (n, r) => n + r.mergedPRs.length + r.openPRs.length,
+            0,
+          );
+          const content = `::linkedin\n\n${synthesis}`;
+          await writer.write(outputPath, content);
+
+          log.info(
+            `Synthesis written: ${outputPath} (${activeRepos.length} repos, ${totalPRs} PRs)`,
+          );
+
+          // 7. Emit synthesis written signal
+          await bus.emit({
+            type: "github.synthesis.written",
+            id: crypto.randomUUID(),
+            ts: Date.now(),
+            payload: {
+              outputPath,
+              scanDate,
+              reposIncluded: activeRepos.length,
+              totalPRs,
+              linkedinReady: true,
+            },
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log.error(`GitHub watcher failed for ${scanDate}: ${msg}`);
+
+          await bus.emit({
+            type: "github.synthesis.written",
+            id: crypto.randomUUID(),
+            ts: Date.now(),
+            payload: {
+              outputPath,
+              scanDate,
+              reposIncluded: 0,
+              totalPRs: 0,
+              linkedinReady: false,
+              error: msg,
+            },
+          });
+        }
+      });
+
+      return () => {
+        unsubCron();
+        log.info("GitHub watcher responder stopped");
+      };
+    },
+  };
+}

--- a/src/cadence/responders/github-watcher/prompts.test.ts
+++ b/src/cadence/responders/github-watcher/prompts.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSynthesisSystemPrompt,
+  buildSynthesisUserPrompt,
+  parseSynthesisResponse,
+} from "./prompts.js";
+import type { RepoScanResult } from "./types.js";
+
+function makeRepo(overrides: Partial<RepoScanResult> = {}): RepoScanResult {
+  return {
+    name: "test-repo",
+    fullName: "Peleke/test-repo",
+    mergedPRs: [],
+    openPRs: [],
+    buildlogEntries: [],
+    ...overrides,
+  };
+}
+
+describe("buildSynthesisSystemPrompt", () => {
+  it("returns a non-empty system prompt", () => {
+    const prompt = buildSynthesisSystemPrompt();
+    expect(prompt.length).toBeGreaterThan(100);
+  });
+
+  it("mentions LinkedIn", () => {
+    const prompt = buildSynthesisSystemPrompt();
+    expect(prompt).toContain("LinkedIn");
+  });
+
+  it("mentions first person", () => {
+    const prompt = buildSynthesisSystemPrompt();
+    expect(prompt).toContain("first person");
+  });
+});
+
+describe("buildSynthesisUserPrompt", () => {
+  it("includes the scan date", () => {
+    const prompt = buildSynthesisUserPrompt([], "2026-02-26");
+    expect(prompt).toContain("2026-02-26");
+  });
+
+  it("includes repo names", () => {
+    const repos = [makeRepo({ fullName: "Peleke/openclaw" })];
+    const prompt = buildSynthesisUserPrompt(repos, "2026-02-26");
+    expect(prompt).toContain("Peleke/openclaw");
+  });
+
+  it("includes merged PRs", () => {
+    const repos = [
+      makeRepo({
+        mergedPRs: [{ number: 42, title: "Add feature X", url: "https://github.com/x/42" }],
+      }),
+    ];
+    const prompt = buildSynthesisUserPrompt(repos, "2026-02-26");
+    expect(prompt).toContain("#42");
+    expect(prompt).toContain("Add feature X");
+    expect(prompt).toContain("Merged PRs");
+  });
+
+  it("includes open PRs", () => {
+    const repos = [
+      makeRepo({
+        openPRs: [{ number: 7, title: "WIP: Refactor", url: "https://github.com/x/7" }],
+      }),
+    ];
+    const prompt = buildSynthesisUserPrompt(repos, "2026-02-26");
+    expect(prompt).toContain("#7");
+    expect(prompt).toContain("Open PRs");
+  });
+
+  it("includes buildlog entries", () => {
+    const repos = [
+      makeRepo({
+        buildlogEntries: [{ name: "2026-02-26.md", content: "Shipped the overlay fix" }],
+      }),
+    ];
+    const prompt = buildSynthesisUserPrompt(repos, "2026-02-26");
+    expect(prompt).toContain("Buildlog Entries");
+    expect(prompt).toContain("Shipped the overlay fix");
+  });
+
+  it("handles multiple repos", () => {
+    const repos = [
+      makeRepo({ fullName: "Peleke/openclaw" }),
+      makeRepo({ fullName: "Peleke/linwheel" }),
+    ];
+    const prompt = buildSynthesisUserPrompt(repos, "2026-02-26");
+    expect(prompt).toContain("Peleke/openclaw");
+    expect(prompt).toContain("Peleke/linwheel");
+  });
+
+  it("handles empty repos array", () => {
+    const prompt = buildSynthesisUserPrompt([], "2026-02-26");
+    expect(prompt).toContain("2026-02-26");
+    expect(prompt).toContain("Synthesize");
+  });
+});
+
+describe("parseSynthesisResponse", () => {
+  it("returns trimmed response for valid markdown", () => {
+    const input =
+      "  # Today I shipped a major feature\n\nIt was great. Lots of progress across repos.  ";
+    const result = parseSynthesisResponse(input);
+    expect(result).toBe(
+      "# Today I shipped a major feature\n\nIt was great. Lots of progress across repos.",
+    );
+  });
+
+  it("returns null for too-short responses", () => {
+    expect(parseSynthesisResponse("")).toBeNull();
+    expect(parseSynthesisResponse("Short.")).toBeNull();
+    expect(parseSynthesisResponse("a".repeat(49))).toBeNull();
+  });
+
+  it("accepts responses at exactly 50 chars", () => {
+    const input = "a".repeat(50);
+    expect(parseSynthesisResponse(input)).toBe(input);
+  });
+
+  it("strips markdown code fences", () => {
+    const input =
+      "```markdown\n# My synthesis\n\nContent here that is long enough to pass the check.\n```";
+    const result = parseSynthesisResponse(input);
+    expect(result).not.toContain("```");
+    expect(result).toContain("# My synthesis");
+  });
+
+  it("strips md code fences", () => {
+    const input =
+      "```md\n# Synthesis\n\nLong enough content for the minimum length requirement here.\n```";
+    const result = parseSynthesisResponse(input);
+    expect(result).not.toContain("```");
+  });
+
+  it("strips bare code fences", () => {
+    const input =
+      "```\n# Synthesis output\n\nLong enough content to pass the minimum length check here.\n```";
+    const result = parseSynthesisResponse(input);
+    expect(result).not.toContain("```");
+  });
+
+  it("preserves internal code blocks", () => {
+    const input =
+      "# Synthesis\n\nHere is some code:\n\n```typescript\nconst x = 1;\n```\n\nAnd more text to make it long enough.";
+    const result = parseSynthesisResponse(input);
+    expect(result).toContain("```typescript");
+  });
+});

--- a/src/cadence/responders/github-watcher/prompts.test.ts
+++ b/src/cadence/responders/github-watcher/prompts.test.ts
@@ -93,7 +93,7 @@ describe("buildSynthesisUserPrompt", () => {
   it("handles empty repos array", () => {
     const prompt = buildSynthesisUserPrompt([], "2026-02-26");
     expect(prompt).toContain("2026-02-26");
-    expect(prompt).toContain("Synthesize");
+    expect(prompt).toContain("beats");
   });
 });
 

--- a/src/cadence/responders/github-watcher/prompts.ts
+++ b/src/cadence/responders/github-watcher/prompts.ts
@@ -1,0 +1,90 @@
+/**
+ * LLM prompts for GitHub activity synthesis.
+ *
+ * Takes structured GitHub scan data and produces a narrative
+ * engineering log suitable for LinkedIn publishing.
+ */
+
+import type { RepoScanResult } from "./types.js";
+
+/**
+ * System prompt for the synthesis LLM call.
+ */
+export function buildSynthesisSystemPrompt(): string {
+  return `You are a technical writer who synthesizes daily GitHub activity into a concise, narrative engineering log.
+
+Your output will be published on LinkedIn, so write in first person, with a conversational but professional tone.
+
+Guidelines:
+- Lead with the most impactful work (shipped features, merged PRs, architecture decisions)
+- Group related work across repos when it tells a coherent story
+- Include specific technical details that demonstrate craft (not vague platitudes)
+- Reference PR numbers and repo names naturally
+- If buildlog entries exist, weave their insights into the narrative
+- Keep it under 800 words
+- Use markdown formatting (headers, bold, lists) for readability
+- Do NOT include frontmatter or YAML headers
+- Do NOT wrap the response in code blocks`;
+}
+
+/**
+ * Build the user prompt from scan results.
+ */
+export function buildSynthesisUserPrompt(repos: RepoScanResult[], scanDate: string): string {
+  const sections: string[] = [`GitHub Activity for ${scanDate}`, ""];
+
+  for (const repo of repos) {
+    const parts: string[] = [`## ${repo.fullName}`];
+
+    if (repo.mergedPRs.length > 0) {
+      parts.push("### Merged PRs");
+      for (const pr of repo.mergedPRs) {
+        parts.push(`- #${pr.number}: ${pr.title} (${pr.url})`);
+      }
+    }
+
+    if (repo.openPRs.length > 0) {
+      parts.push("### Open PRs");
+      for (const pr of repo.openPRs) {
+        parts.push(`- #${pr.number}: ${pr.title} (${pr.url})`);
+      }
+    }
+
+    if (repo.buildlogEntries.length > 0) {
+      parts.push("### Buildlog Entries");
+      for (const entry of repo.buildlogEntries) {
+        parts.push(`- ${entry.name}:`);
+        parts.push(`  ${entry.content}`);
+      }
+    }
+
+    sections.push(parts.join("\n"));
+  }
+
+  sections.push(
+    "",
+    "Synthesize this into a narrative engineering log. Focus on the story of what was built and why it matters.",
+  );
+
+  return sections.join("\n");
+}
+
+/**
+ * Parse the LLM response. The response IS the markdown — no JSON parsing needed.
+ * Returns null if the response is too short to be useful.
+ */
+export function parseSynthesisResponse(response: string): string | null {
+  const trimmed = response.trim();
+
+  // Strip code fences if the LLM wraps output in them
+  const unwrapped = trimmed
+    .replace(/^```(?:markdown|md)?\n?/, "")
+    .replace(/\n?```$/, "")
+    .trim();
+
+  if (unwrapped.length < 50) {
+    return null;
+  }
+
+  return unwrapped;
+}

--- a/src/cadence/responders/github-watcher/prompts.ts
+++ b/src/cadence/responders/github-watcher/prompts.ts
@@ -11,20 +11,31 @@ import type { RepoScanResult } from "./types.js";
  * System prompt for the synthesis LLM call.
  */
 export function buildSynthesisSystemPrompt(): string {
-  return `You are a technical writer who synthesizes daily GitHub activity into a concise, narrative engineering log.
+  return `You are writing source material for a LinkedIn content pipeline. Your output will be fed into an AI reshape engine that decomposes it into angle-specific LinkedIn posts. You are NOT writing LinkedIn posts — you are writing beat-rich source notes.
 
-Your output will be published on LinkedIn, so write in first person, with a conversational but professional tone.
+Write in first person as the author (a technical founder building in public).
 
-Guidelines:
-- Lead with the most impactful work (shipped features, merged PRs, architecture decisions)
-- Group related work across repos when it tells a coherent story
-- Include specific technical details that demonstrate craft (not vague platitudes)
-- Reference PR numbers and repo names naturally
-- If buildlog entries exist, weave their insights into the narrative
-- Keep it under 800 words
-- Use markdown formatting (headers, bold, lists) for readability
-- Do NOT include frontmatter or YAML headers
-- Do NOT wrap the response in code blocks`;
+Structure your output as 3-5 BEATS. Each beat is a discrete story unit (2-4 sentences) that captures one moment, decision, struggle, or insight. The reshape engine picks different beats for different post angles, so each beat should stand alone as interesting material.
+
+Beat types that work best (include at least 3 different types):
+- SHIPPING BEAT: Concrete "I did X" with numbers (PRs merged, files changed, tests passing)
+- ARCHITECTURE BEAT: A technical decision explained simply enough for a senior non-specialist
+- STRUGGLE BEAT: Something that went wrong, took longer than expected, or challenged an assumption. Be specific about the failure. This is the most important beat — LinkedIn posts with tension outperform everything else.
+- INSIGHT BEAT: A lesson or contrarian take. "The thing nobody tells you" or "what I wish I knew"
+- CONNECTION BEAT: Link this work to a bigger trend, an open question, or a surprising parallel from another domain
+
+Prose constraints:
+- Specifics over abstractions. "3 PRs across 2 repos" not "made good progress"
+- Active voice. "I shipped" not "the feature was shipped"
+- One idea per sentence
+- Name tools and technologies explicitly (TypeScript, Obsidian, overlayfs — not "a language" or "a tool")
+- NO LinkedIn formatting (no short-line tricks, no emojis, no hashtags)
+- NO markdown headers (the reshape engine handles structure)
+- NO frontmatter or YAML
+- NO code blocks wrapping the response
+- End with an open thread: a question, a "what's next," or an unresolved tension
+- 300-800 words ideal. Never exceed 1200.
+- Write natural flowing prose, not bullet points`;
 }
 
 /**
@@ -63,7 +74,7 @@ export function buildSynthesisUserPrompt(repos: RepoScanResult[], scanDate: stri
 
   sections.push(
     "",
-    "Synthesize this into a narrative engineering log. Focus on the story of what was built and why it matters.",
+    "Write 3-5 beats from this activity. Lead with the most impactful shipping beat. Include at least one struggle or surprise (something that went wrong or was counterintuitive). End with an open thread — a question or unresolved tension. Do NOT write a laundry list of commits. Pick the 1-2 most interesting threads and tell their story with specific details.",
   );
 
   return sections.join("\n");

--- a/src/cadence/responders/github-watcher/types.ts
+++ b/src/cadence/responders/github-watcher/types.ts
@@ -1,0 +1,99 @@
+/**
+ * GitHub Watcher responder types.
+ *
+ * Config and injectable dependency interfaces for the nightly
+ * GitHub activity scanner and synthesis responder.
+ */
+
+import type { OpenClawPayloadMap } from "../../signals.js";
+
+/**
+ * Configuration for the GitHub watcher responder.
+ */
+export interface GitHubWatcherConfig {
+  /** GitHub username to scan repos for (default: "Peleke") */
+  owner: string;
+
+  /** Scan time in HH:MM format (default: "21:00") */
+  scanTime: string;
+
+  /** Output directory within vault (default: "Buildlog") */
+  outputDir: string;
+
+  /** Max buildlog entries per repo to include (default: 3) */
+  maxBuildlogEntries: number;
+
+  /** Repos to exclude from scanning */
+  excludeRepos: string[];
+}
+
+export const DEFAULT_GITHUB_WATCHER_CONFIG: GitHubWatcherConfig = {
+  owner: "Peleke",
+  scanTime: "21:00",
+  outputDir: "Buildlog",
+  maxBuildlogEntries: 3,
+  excludeRepos: [],
+};
+
+/**
+ * A GitHub repository summary.
+ */
+export interface GitHubRepo {
+  name: string;
+  fullName: string;
+  archived: boolean;
+  fork: boolean;
+  pushedAt: string;
+}
+
+/**
+ * A GitHub pull request summary.
+ */
+export interface GitHubPR {
+  number: number;
+  title: string;
+  url: string;
+  body: string;
+  mergedAt?: string;
+  createdAt: string;
+}
+
+/**
+ * A buildlog entry from a repo.
+ */
+export interface BuildlogEntry {
+  name: string;
+  content: string;
+}
+
+/**
+ * Injectable GitHub API client interface.
+ */
+export interface GitHubClient {
+  listRepos(owner: string): Promise<GitHubRepo[]>;
+  getMergedPRsForDate(repo: string, date: string): Promise<GitHubPR[]>;
+  getOpenPRs(repo: string): Promise<GitHubPR[]>;
+  hasBuildlogDir(repo: string): Promise<boolean>;
+  getRecentBuildlogEntries(repo: string, limit: number): Promise<BuildlogEntry[]>;
+}
+
+/**
+ * Injectable file writer interface.
+ */
+export interface FileWriter {
+  exists(path: string): Promise<boolean>;
+  write(path: string, content: string): Promise<void>;
+}
+
+/**
+ * Injectable clock for testing.
+ */
+export interface WatcherClock {
+  /** Returns today's date as YYYY-MM-DD */
+  today(): string;
+}
+
+/**
+ * Scan result for a single repo.
+ */
+export type RepoScanResult = OpenClawPayloadMap["github.scan.completed"]["repos"][number];

--- a/src/cadence/responders/index.ts
+++ b/src/cadence/responders/index.ts
@@ -48,3 +48,4 @@ export {
   type LinWheelPublisherConfig,
   DEFAULT_PUBLISHER_CONFIG,
 } from "./linwheel-publisher/types.js";
+export { createGitHubWatcherResponder, type GitHubWatcherOptions } from "./github-watcher/index.js";

--- a/src/cadence/responders/index.ts
+++ b/src/cadence/responders/index.ts
@@ -49,3 +49,4 @@ export {
   DEFAULT_PUBLISHER_CONFIG,
 } from "./linwheel-publisher/types.js";
 export { createGitHubWatcherResponder, type GitHubWatcherOptions } from "./github-watcher/index.js";
+export { createRunlistResponder, type RunlistResponderOptions } from "./runlist/index.js";

--- a/src/cadence/responders/linwheel-publisher/index.ts
+++ b/src/cadence/responders/linwheel-publisher/index.ts
@@ -134,7 +134,12 @@ export function createLinWheelPublisherResponder(options: LinWheelPublisherOptio
           return;
         }
 
-        const filterResult = shouldExtract(content, {
+        // Strip YAML frontmatter before magic string detection.
+        // ObsidianWatcher passes raw content including frontmatter, but
+        // shouldExtract expects content starting at the first real line.
+        const contentBody = content.replace(/^---\n[\s\S]*?\n---\n?/, "");
+
+        const filterResult = shouldExtract(contentBody, {
           magicString: config.magicString,
           minContentLength: config.minContentLength,
         });

--- a/src/cadence/responders/runlist/formatter.ts
+++ b/src/cadence/responders/runlist/formatter.ts
@@ -1,0 +1,90 @@
+/**
+ * Runlist message formatter.
+ *
+ * Formats morning ping and nightly recap messages for Telegram.
+ * No emoji. No motivation. Just the list and what's stale.
+ */
+
+import type { RunletSummary, TaskCompletion, RunletTask } from "./types.js";
+
+/**
+ * Format the morning ping message.
+ *
+ * Example:
+ * ```
+ * Morning. 3 Do First, 2 Block Time, 1 Batch.
+ * Top: LinkedIn outreach (5 convos).
+ * Carried from yesterday: Atlanta meetup search.
+ * ```
+ */
+export function formatMorningPing(summary: RunletSummary): string {
+  const { counts, top_task, carried, focus } = summary;
+
+  const parts: string[] = [];
+
+  // Line 1: counts
+  const countParts: string[] = [];
+  if (counts.do_first > 0) countParts.push(`${counts.do_first} Do First`);
+  if (counts.block_time > 0) countParts.push(`${counts.block_time} Block Time`);
+  if (counts.batch > 0) countParts.push(`${counts.batch} Batch`);
+
+  if (countParts.length === 0) {
+    parts.push(`Morning. Nothing on the list. Focus: ${focus}.`);
+    return parts.join("\n");
+  }
+
+  parts.push(`Morning. ${countParts.join(", ")}. Focus: ${focus}.`);
+
+  // Line 2: top task
+  if (top_task) {
+    parts.push(`Top: ${top_task}.`);
+  }
+
+  // Line 3: carries
+  if (carried.length > 0) {
+    parts.push(`Carried from yesterday: ${carried.join(", ")}.`);
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Format the nightly recap message.
+ *
+ * Example:
+ * ```
+ * Nightly. 4/6 done.
+ * Unchecked: Discord servers, Atlanta meetups.
+ * Atlanta meetups carried 3x — block time tomorrow or kill it.
+ * ```
+ */
+export function formatNightlyRecap(
+  summary: RunletSummary,
+  completion: TaskCompletion,
+  forcedDecisions: RunletTask[],
+): string {
+  const total = completion.done.length + completion.pending.length;
+  const parts: string[] = [];
+
+  // Line 1: completion rate
+  if (total === 0) {
+    parts.push("Nightly. No tasks tracked today.");
+    return parts.join("\n");
+  }
+
+  parts.push(`Nightly. ${completion.done.length}/${total} done.`);
+
+  // Line 2: unchecked items
+  if (completion.pending.length > 0) {
+    const unchecked = completion.pending.slice(0, 5); // Cap at 5 for readability
+    const suffix = completion.pending.length > 5 ? ` (+${completion.pending.length - 5} more)` : "";
+    parts.push(`Unchecked: ${unchecked.join(", ")}${suffix}.`);
+  }
+
+  // Line 3+: forced decisions (3-carry rule)
+  for (const task of forcedDecisions) {
+    parts.push(`${task.description} carried 3x — block time tomorrow or kill it.`);
+  }
+
+  return parts.join("\n");
+}

--- a/src/cadence/responders/runlist/index.ts
+++ b/src/cadence/responders/runlist/index.ts
@@ -1,0 +1,199 @@
+/**
+ * Runlist responder.
+ *
+ * Subscribes to cadence.cron.fired signals (filtered by jobId),
+ * reads today's runlist from the Obsidian vault, parses the
+ * RUNLET_SUMMARY JSON, and sends a morning ping or nightly recap
+ * via Telegram.
+ */
+
+import crypto from "node:crypto";
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import type { SignalBus } from "@peleke.s/cadence";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { sendMessageTelegram } from "../../../telegram/send.js";
+import type { OpenClawSignal } from "../../signals.js";
+import type { Responder } from "../index.js";
+import type { RunlistResponderConfig } from "./types.js";
+import { parseRunletSummary, parseTaskCompletion, findForcedDecisions } from "./parser.js";
+import { formatMorningPing, formatNightlyRecap } from "./formatter.js";
+
+const log = createSubsystemLogger("cadence").child("runlist");
+
+export interface RunlistResponderOptions {
+  /** Path to Obsidian vault root */
+  vaultPath: string;
+
+  /** Telegram chat ID for delivery */
+  telegramChatId: string;
+
+  /** Optional Telegram account ID */
+  telegramAccountId?: string;
+
+  /** Cron job IDs that trigger this responder */
+  cronTriggerJobIds?: string[];
+
+  /** Directory within vault containing runlist files */
+  runlistDir?: string;
+
+  /** File reader for testability */
+  fileReader?: FileReader;
+
+  /** Clock for testability */
+  clock?: RunlistClock;
+}
+
+export interface FileReader {
+  exists(path: string): boolean;
+  read(path: string): Promise<string>;
+}
+
+export interface RunlistClock {
+  today(): string;
+}
+
+function createDefaultFileReader(): FileReader {
+  return {
+    exists: (p: string) => existsSync(p),
+    read: (p: string) => readFile(p, "utf-8"),
+  };
+}
+
+function createDefaultClock(): RunlistClock {
+  return {
+    today: () => new Date().toISOString().split("T")[0],
+  };
+}
+
+/**
+ * Read and parse a runlist file. Returns null if file doesn't exist
+ * or can't be parsed. Retries once after 5s on read failure (iCloud sync lag).
+ */
+async function readRunlist(filePath: string, reader: FileReader): Promise<string | null> {
+  if (!reader.exists(filePath)) {
+    return null;
+  }
+
+  try {
+    return await reader.read(filePath);
+  } catch {
+    // Retry once after 5s (iCloud sync delay)
+    log.debug(`First read failed for ${filePath}, retrying in 5s`);
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    try {
+      return await reader.read(filePath);
+    } catch (err) {
+      log.warn(
+        `Failed to read runlist after retry: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+}
+
+/**
+ * Create the runlist responder.
+ */
+export function createRunlistResponder(options: RunlistResponderOptions): Responder {
+  const reader = options.fileReader ?? createDefaultFileReader();
+  const clock = options.clock ?? createDefaultClock();
+  const runlistDir = options.runlistDir ?? "Runlist";
+  const cronTriggerJobIds = options.cronTriggerJobIds ?? ["runlist-morning", "runlist-nightly"];
+
+  return {
+    name: "runlist",
+    description: "Sends morning runlist ping and nightly recap via Telegram",
+
+    register(bus: SignalBus<OpenClawSignal>): () => void {
+      log.info("Runlist responder starting", {
+        runlistDir,
+        cronTriggerJobIds,
+      });
+
+      const unsubCron = bus.on("cadence.cron.fired", async (signal) => {
+        const { jobId } = signal.payload;
+
+        if (!cronTriggerJobIds.includes(jobId)) {
+          return;
+        }
+
+        const today = clock.today();
+        const filePath = path.join(options.vaultPath, runlistDir, `${today}.md`);
+
+        log.info(`Runlist ${jobId} triggered for ${today}`);
+
+        // Read the runlist file
+        const content = await readRunlist(filePath, reader);
+        if (!content) {
+          log.info(`No runlist found at ${filePath}, skipping`);
+          return;
+        }
+
+        // Parse RUNLET_SUMMARY
+        const summary = parseRunletSummary(content);
+        if (!summary) {
+          log.warn(`No RUNLET_SUMMARY found in ${filePath}, skipping`);
+          return;
+        }
+
+        try {
+          if (jobId === "runlist-morning" || jobId.endsWith("-morning")) {
+            // Morning ping
+            const message = formatMorningPing(summary);
+            await sendMessageTelegram(options.telegramChatId, message, {
+              accountId: options.telegramAccountId,
+            });
+
+            await bus.emit({
+              type: "runlist.morning.sent",
+              id: crypto.randomUUID(),
+              ts: Date.now(),
+              payload: {
+                date: today,
+                focus: summary.focus,
+                counts: summary.counts,
+                carried_count: summary.carried_count,
+              },
+            });
+
+            log.info(`Morning ping sent for ${today}`);
+          } else {
+            // Nightly recap
+            const completion = parseTaskCompletion(content);
+            const forcedDecisions = findForcedDecisions(summary.tasks);
+            const message = formatNightlyRecap(summary, completion, forcedDecisions);
+
+            await sendMessageTelegram(options.telegramChatId, message, {
+              accountId: options.telegramAccountId,
+            });
+
+            await bus.emit({
+              type: "runlist.nightly.sent",
+              id: crypto.randomUUID(),
+              ts: Date.now(),
+              payload: {
+                date: today,
+                completed: completion.done.length,
+                pending: completion.pending.length,
+                forcedDecisions: forcedDecisions.map((t) => t.description),
+              },
+            });
+
+            log.info(
+              `Nightly recap sent for ${today}: ${completion.done.length}/${completion.done.length + completion.pending.length} done`,
+            );
+          }
+        } catch (err) {
+          log.error(`Runlist ${jobId} failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      });
+
+      return () => {
+        unsubCron();
+        log.info("Runlist responder stopped");
+      };
+    },
+  };
+}

--- a/src/cadence/responders/runlist/parser.ts
+++ b/src/cadence/responders/runlist/parser.ts
@@ -1,0 +1,87 @@
+/**
+ * Runlist file parser.
+ *
+ * Extracts RUNLET_SUMMARY JSON from HTML comments and
+ * parses markdown checkbox state for completion tracking.
+ */
+
+import type { RunletSummary, TaskCompletion, RunletTask } from "./types.js";
+
+/**
+ * Extract and parse RUNLET_SUMMARY JSON from a runlist markdown file.
+ *
+ * Looks for:
+ * ```
+ * <!-- RUNLET_SUMMARY
+ * { ... }
+ * -->
+ * ```
+ */
+export function parseRunletSummary(content: string): RunletSummary | null {
+  const match = content.match(/<!--\s*RUNLET_SUMMARY\s*\n([\s\S]*?)\n\s*-->/);
+  if (!match) return null;
+
+  try {
+    return JSON.parse(match[1]) as RunletSummary;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse checked/unchecked tasks from markdown checkboxes.
+ *
+ * Matches `- [x]` (done) and `- [ ]` (pending) lines.
+ * Strips entry point sub-items and focus tags.
+ */
+export function parseTaskCompletion(content: string): TaskCompletion {
+  const done: string[] = [];
+  const pending: string[] = [];
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+
+    // Skip entry point lines (indented italic sub-items)
+    if (trimmed.startsWith("- *Entry point:") || trimmed.startsWith("*Entry point:")) {
+      continue;
+    }
+
+    // Skip killed items (strikethrough)
+    if (trimmed.startsWith("- ~~")) {
+      continue;
+    }
+
+    const doneMatch = trimmed.match(/^- \[x\]\s+(.+)/i);
+    if (doneMatch) {
+      done.push(cleanTaskText(doneMatch[1]));
+      continue;
+    }
+
+    const pendingMatch = trimmed.match(/^- \[ \]\s+(.+)/);
+    if (pendingMatch) {
+      pending.push(cleanTaskText(pendingMatch[1]));
+      continue;
+    }
+  }
+
+  return { done, pending };
+}
+
+/**
+ * Find tasks that have been carried 3+ times (forced decision needed).
+ */
+export function findForcedDecisions(tasks: RunletTask[]): RunletTask[] {
+  // Tasks with carried_from set are carries. The 3-carry rule
+  // promotes them to kill with a flag in the markdown. We detect
+  // these by checking for "carried 3x" in the kill quadrant tasks.
+  // But we can also detect from the summary: if a task is in kill
+  // quadrant and has carried_from set, it's a forced decision.
+  return tasks.filter((t) => t.quadrant === "kill" && t.carried_from !== null);
+}
+
+/**
+ * Strip focus tags like [H], [M], [C] and trailing whitespace.
+ */
+function cleanTaskText(text: string): string {
+  return text.replace(/\s*\[[A-Z]\]\s*/g, " ").trim();
+}

--- a/src/cadence/responders/runlist/test/fixtures/runlist-3-carry.md
+++ b/src/cadence/responders/runlist/test/fixtures/runlist-3-carry.md
@@ -1,0 +1,42 @@
+# Runlist — 2026-03-16
+
+**Focus**: Money
+
+## Do First (low energy, moves money)
+- [ ] LinkedIn outreach: 5 new conversations
+- [ ] Reply to comments
+
+## Block Time (high energy, moves money)
+- [ ] Design the API schema
+  - *Entry point: open schema.ts, add one empty interface for the first endpoint*
+
+## Batch (low energy, doesn't move money)
+- [ ] Update billing info
+
+## Kill or Delegate
+- ~~Atlanta meetup search~~ → carried 3x. Block time for it tomorrow or kill it.
+- ~~Fix carousel bug~~ → not revenue-blocking; backlog it
+
+---
+*Generated from braindump. Review ≤ 2 min.*
+*Carried items: 1 from 2026-03-13.*
+
+<!-- RUNLET_SUMMARY
+{
+  "date": "2026-03-16",
+  "focus": "Money",
+  "known_focuses": ["Money", "Health"],
+  "counts": { "do_first": 2, "block_time": 1, "batch": 1, "kill": 2 },
+  "top_task": "LinkedIn outreach: 5 new conversations",
+  "carried": ["Atlanta meetup search"],
+  "carried_count": 1,
+  "tasks": [
+    { "description": "LinkedIn outreach: 5 new conversations", "quadrant": "do_first", "energy": "low", "moves_focus": true, "focuses": ["Money"], "carried_from": null },
+    { "description": "Reply to comments", "quadrant": "do_first", "energy": "low", "moves_focus": true, "focuses": ["Money"], "carried_from": null },
+    { "description": "Design the API schema", "quadrant": "block_time", "energy": "high", "moves_focus": true, "focuses": ["Money"], "carried_from": null },
+    { "description": "Update billing info", "quadrant": "batch", "energy": "low", "moves_focus": false, "focuses": [], "carried_from": null },
+    { "description": "Atlanta meetup search", "quadrant": "kill", "energy": "high", "moves_focus": false, "focuses": ["Career"], "carried_from": "2026-03-13" },
+    { "description": "Fix carousel bug", "quadrant": "kill", "energy": "high", "moves_focus": false, "focuses": [], "carried_from": null }
+  ]
+}
+-->

--- a/src/cadence/responders/runlist/test/fixtures/runlist-full.md
+++ b/src/cadence/responders/runlist/test/fixtures/runlist-full.md
@@ -1,0 +1,52 @@
+# Runlist — 2026-03-13
+
+**Focus**: Money
+
+## Do First (low energy, moves money)
+- [ ] LinkedIn outreach: 5 new conversations
+- [ ] Reply to all post comments (< 2hr old)
+- [ ] Follow up on 3-5 day old unanswered outreach
+
+## Block Time (high energy, moves money)
+- [ ] Discord: join 3 servers, answer 2-3 questions with substance
+  - *Entry point: open Anthropic Discord → MCP channel → find one question you know the answer to*
+- [ ] Atlanta meetup search → register for 2-3 events
+  - *Entry point: open lu.ma, search "Atlanta AI", bookmark first 3 results*
+
+## Batch (low energy, doesn't move money)
+
+**Cross-posting**
+- [ ] Dev.to/Hashnode account setup + cross-post AX-07
+
+**Onboarding**
+- [ ] Onboard buddy to LinWheel — send invite + walkthrough doc
+
+## Kill or Delegate
+- ~~Rhythm passes on AX-05/06/07~~ → weekend, not tomorrow
+- ~~Fix carousel bug~~ → not revenue-blocking; backlog it
+
+---
+*Generated from braindump. Review ≤ 2 min.*
+
+<!-- RUNLET_SUMMARY
+{
+  "date": "2026-03-13",
+  "focus": "Money",
+  "known_focuses": ["Money", "Career", "Health"],
+  "counts": { "do_first": 3, "block_time": 2, "batch": 2, "kill": 2 },
+  "top_task": "LinkedIn outreach: 5 new conversations",
+  "carried": [],
+  "carried_count": 0,
+  "tasks": [
+    { "description": "LinkedIn outreach: 5 new conversations", "quadrant": "do_first", "energy": "low", "moves_focus": true, "focuses": ["Money", "Career"], "carried_from": null },
+    { "description": "Reply to all post comments (< 2hr old)", "quadrant": "do_first", "energy": "low", "moves_focus": true, "focuses": ["Money"], "carried_from": null },
+    { "description": "Follow up on 3-5 day old unanswered outreach", "quadrant": "do_first", "energy": "low", "moves_focus": true, "focuses": ["Money"], "carried_from": null },
+    { "description": "Discord: join 3 servers, answer 2-3 questions with substance", "quadrant": "block_time", "energy": "high", "moves_focus": true, "focuses": ["Money", "Career"], "carried_from": null },
+    { "description": "Atlanta meetup search → register for 2-3 events", "quadrant": "block_time", "energy": "high", "moves_focus": true, "focuses": ["Money", "Career"], "carried_from": null },
+    { "description": "Dev.to/Hashnode account setup + cross-post AX-07", "quadrant": "batch", "energy": "low", "moves_focus": false, "focuses": ["Career"], "carried_from": null },
+    { "description": "Onboard buddy to LinWheel", "quadrant": "batch", "energy": "low", "moves_focus": false, "focuses": [], "carried_from": null },
+    { "description": "Rhythm passes on AX-05/06/07", "quadrant": "kill", "energy": "high", "moves_focus": false, "focuses": ["Career"], "carried_from": null },
+    { "description": "Fix carousel bug", "quadrant": "kill", "energy": "high", "moves_focus": false, "focuses": [], "carried_from": null }
+  ]
+}
+-->

--- a/src/cadence/responders/runlist/test/fixtures/runlist-no-summary.md
+++ b/src/cadence/responders/runlist/test/fixtures/runlist-no-summary.md
@@ -1,0 +1,13 @@
+# Runlist — 2026-03-13
+
+**Focus**: Money
+
+## Do First (low energy, moves money)
+- [ ] LinkedIn outreach: 5 new conversations
+- [x] Reply to all post comments
+
+## Block Time (high energy, moves money)
+- [ ] Discord: join 3 servers
+
+## Kill or Delegate
+- ~~Fix carousel bug~~ → backlog it

--- a/src/cadence/responders/runlist/test/fixtures/runlist-partial.md
+++ b/src/cadence/responders/runlist/test/fixtures/runlist-partial.md
@@ -1,0 +1,52 @@
+# Runlist — 2026-03-13
+
+**Focus**: Money
+
+## Do First (low energy, moves money)
+- [x] LinkedIn outreach: 5 new conversations
+- [x] Reply to all post comments (< 2hr old)
+- [ ] Follow up on 3-5 day old unanswered outreach
+
+## Block Time (high energy, moves money)
+- [x] Discord: join 3 servers, answer 2-3 questions with substance
+  - *Entry point: open Anthropic Discord → MCP channel → find one question you know the answer to*
+- [ ] Atlanta meetup search → register for 2-3 events
+  - *Entry point: open lu.ma, search "Atlanta AI", bookmark first 3 results*
+
+## Batch (low energy, doesn't move money)
+
+**Cross-posting**
+- [x] Dev.to/Hashnode account setup + cross-post AX-07
+
+**Onboarding**
+- [ ] Onboard buddy to LinWheel — send invite + walkthrough doc
+
+## Kill or Delegate
+- ~~Rhythm passes on AX-05/06/07~~ → weekend, not tomorrow
+- ~~Fix carousel bug~~ → not revenue-blocking; backlog it
+
+---
+*Generated from braindump. Review ≤ 2 min.*
+
+<!-- RUNLET_SUMMARY
+{
+  "date": "2026-03-13",
+  "focus": "Money",
+  "known_focuses": ["Money", "Career", "Health"],
+  "counts": { "do_first": 3, "block_time": 2, "batch": 2, "kill": 2 },
+  "top_task": "LinkedIn outreach: 5 new conversations",
+  "carried": [],
+  "carried_count": 0,
+  "tasks": [
+    { "description": "LinkedIn outreach: 5 new conversations", "quadrant": "do_first", "energy": "low", "moves_focus": true, "focuses": ["Money", "Career"], "carried_from": null },
+    { "description": "Reply to all post comments (< 2hr old)", "quadrant": "do_first", "energy": "low", "moves_focus": true, "focuses": ["Money"], "carried_from": null },
+    { "description": "Follow up on 3-5 day old unanswered outreach", "quadrant": "do_first", "energy": "low", "moves_focus": true, "focuses": ["Money"], "carried_from": null },
+    { "description": "Discord: join 3 servers, answer 2-3 questions with substance", "quadrant": "block_time", "energy": "high", "moves_focus": true, "focuses": ["Money", "Career"], "carried_from": null },
+    { "description": "Atlanta meetup search → register for 2-3 events", "quadrant": "block_time", "energy": "high", "moves_focus": true, "focuses": ["Money", "Career"], "carried_from": null },
+    { "description": "Dev.to/Hashnode account setup + cross-post AX-07", "quadrant": "batch", "energy": "low", "moves_focus": false, "focuses": ["Career"], "carried_from": null },
+    { "description": "Onboard buddy to LinWheel", "quadrant": "batch", "energy": "low", "moves_focus": false, "focuses": [], "carried_from": null },
+    { "description": "Rhythm passes on AX-05/06/07", "quadrant": "kill", "energy": "high", "moves_focus": false, "focuses": ["Career"], "carried_from": null },
+    { "description": "Fix carousel bug", "quadrant": "kill", "energy": "high", "moves_focus": false, "focuses": [], "carried_from": null }
+  ]
+}
+-->

--- a/src/cadence/responders/runlist/test/formatter.test.ts
+++ b/src/cadence/responders/runlist/test/formatter.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { formatMorningPing, formatNightlyRecap } from "../formatter.js";
+import { parseRunletSummary, parseTaskCompletion, findForcedDecisions } from "../parser.js";
+
+const fixturesDir = path.join(import.meta.dirname, "fixtures");
+
+function readFixture(name: string): string {
+  return readFileSync(path.join(fixturesDir, name), "utf-8");
+}
+
+describe("formatMorningPing", () => {
+  it("formats a standard morning message", () => {
+    const content = readFixture("runlist-full.md");
+    const summary = parseRunletSummary(content)!;
+    const message = formatMorningPing(summary);
+
+    expect(message).toContain("Morning.");
+    expect(message).toContain("3 Do First");
+    expect(message).toContain("2 Block Time");
+    expect(message).toContain("2 Batch");
+    expect(message).toContain("Focus: Money");
+    expect(message).toContain("Top: LinkedIn outreach");
+  });
+
+  it("includes carried items when present", () => {
+    const content = readFixture("runlist-3-carry.md");
+    const summary = parseRunletSummary(content)!;
+    const message = formatMorningPing(summary);
+
+    expect(message).toContain("Carried from yesterday: Atlanta meetup search");
+  });
+
+  it("omits carried line when no carries", () => {
+    const content = readFixture("runlist-full.md");
+    const summary = parseRunletSummary(content)!;
+    const message = formatMorningPing(summary);
+
+    expect(message).not.toContain("Carried from yesterday");
+  });
+
+  it("contains no emoji", () => {
+    const content = readFixture("runlist-full.md");
+    const summary = parseRunletSummary(content)!;
+    const message = formatMorningPing(summary);
+
+    // Check for common emoji ranges
+    expect(message).not.toMatch(/[\u{1F600}-\u{1F64F}]/u);
+    expect(message).not.toMatch(/[\u{1F300}-\u{1F5FF}]/u);
+    expect(message).not.toMatch(/[\u{1F680}-\u{1F6FF}]/u);
+  });
+
+  it("handles empty runlist", () => {
+    const summary = {
+      date: "2026-03-13",
+      focus: "Money",
+      known_focuses: ["Money"],
+      counts: { do_first: 0, block_time: 0, batch: 0, kill: 0 },
+      top_task: "",
+      carried: [],
+      carried_count: 0,
+      tasks: [],
+    };
+    const message = formatMorningPing(summary);
+
+    expect(message).toContain("Nothing on the list");
+  });
+});
+
+describe("formatNightlyRecap", () => {
+  it("formats completion rate", () => {
+    const content = readFixture("runlist-partial.md");
+    const summary = parseRunletSummary(content)!;
+    const completion = parseTaskCompletion(content);
+    const forced = findForcedDecisions(summary.tasks);
+    const message = formatNightlyRecap(summary, completion, forced);
+
+    expect(message).toContain("Nightly.");
+    expect(message).toContain("4/7 done.");
+  });
+
+  it("lists unchecked items", () => {
+    const content = readFixture("runlist-partial.md");
+    const summary = parseRunletSummary(content)!;
+    const completion = parseTaskCompletion(content);
+    const forced = findForcedDecisions(summary.tasks);
+    const message = formatNightlyRecap(summary, completion, forced);
+
+    expect(message).toContain("Unchecked:");
+    expect(message).toContain("Atlanta meetup");
+  });
+
+  it("includes forced decision warnings", () => {
+    const content = readFixture("runlist-3-carry.md");
+    const summary = parseRunletSummary(content)!;
+    const completion = parseTaskCompletion(content);
+    const forced = findForcedDecisions(summary.tasks);
+    const message = formatNightlyRecap(summary, completion, forced);
+
+    expect(message).toContain("carried 3x");
+    expect(message).toContain("block time tomorrow or kill it");
+  });
+
+  it("handles all-done scenario", () => {
+    const summary = {
+      date: "2026-03-13",
+      focus: "Money",
+      known_focuses: ["Money"],
+      counts: { do_first: 3, block_time: 0, batch: 0, kill: 0 },
+      top_task: "",
+      carried: [],
+      carried_count: 0,
+      tasks: [],
+    };
+    const completion = { done: ["a", "b", "c"], pending: [] };
+    const message = formatNightlyRecap(summary, completion, []);
+
+    expect(message).toContain("3/3 done.");
+    expect(message).not.toContain("Unchecked:");
+  });
+});

--- a/src/cadence/responders/runlist/test/index.test.ts
+++ b/src/cadence/responders/runlist/test/index.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { createRunlistResponder } from "../index.js";
+import type { FileReader, RunlistClock } from "../index.js";
+
+// Mock telegram send
+vi.mock("../../../../telegram/send.js", () => ({
+  sendMessageTelegram: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+// Mock logger
+vi.mock("../../../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    child: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+const fixturesDir = path.join(import.meta.dirname, "fixtures");
+
+function createMockBus() {
+  const handlers = new Map<string, Function[]>();
+  return {
+    on: vi.fn((type: string, handler: Function) => {
+      if (!handlers.has(type)) handlers.set(type, []);
+      handlers.get(type)!.push(handler);
+      return () => {};
+    }),
+    emit: vi.fn().mockResolvedValue(undefined),
+    onAny: vi.fn(),
+    // Helper to trigger handlers
+    async fire(type: string, payload: Record<string, unknown>) {
+      const fns = handlers.get(type) ?? [];
+      for (const fn of fns) {
+        await fn({
+          type,
+          id: "test-signal-id",
+          ts: Date.now(),
+          payload,
+        });
+      }
+    },
+  };
+}
+
+function createMockFileReader(files: Record<string, string>): FileReader {
+  return {
+    exists: (p: string) => p in files,
+    read: async (p: string) => {
+      if (!(p in files)) throw new Error(`File not found: ${p}`);
+      return files[p];
+    },
+  };
+}
+
+function createMockClock(date: string): RunlistClock {
+  return { today: () => date };
+}
+
+describe("createRunlistResponder", () => {
+  let sendMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("../../../../telegram/send.js");
+    sendMock = mod.sendMessageTelegram as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it("ignores cron signals with non-matching jobId", async () => {
+    const bus = createMockBus();
+    const responder = createRunlistResponder({
+      vaultPath: "/vault",
+      telegramChatId: "123",
+      fileReader: createMockFileReader({}),
+      clock: createMockClock("2026-03-13"),
+    });
+
+    responder.register(bus as any);
+
+    await bus.fire("cadence.cron.fired", {
+      jobId: "github-watcher",
+      jobName: "GitHub Watcher",
+      expr: "0 21 * * *",
+      firedAt: Date.now(),
+    });
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when no runlist file exists", async () => {
+    const bus = createMockBus();
+    const responder = createRunlistResponder({
+      vaultPath: "/vault",
+      telegramChatId: "123",
+      fileReader: createMockFileReader({}),
+      clock: createMockClock("2026-03-13"),
+    });
+
+    responder.register(bus as any);
+
+    await bus.fire("cadence.cron.fired", {
+      jobId: "runlist-morning",
+      jobName: "Runlist Morning Ping",
+      expr: "30 7 * * *",
+      firedAt: Date.now(),
+    });
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("sends morning ping with correct message", async () => {
+    const fullContent = readFileSync(path.join(fixturesDir, "runlist-full.md"), "utf-8");
+    const bus = createMockBus();
+    const responder = createRunlistResponder({
+      vaultPath: "/vault",
+      telegramChatId: "test-chat",
+      fileReader: createMockFileReader({
+        "/vault/Runlist/2026-03-13.md": fullContent,
+      }),
+      clock: createMockClock("2026-03-13"),
+    });
+
+    responder.register(bus as any);
+
+    await bus.fire("cadence.cron.fired", {
+      jobId: "runlist-morning",
+      jobName: "Runlist Morning Ping",
+      expr: "30 7 * * *",
+      firedAt: Date.now(),
+    });
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    const [chatId, message] = sendMock.mock.calls[0];
+    expect(chatId).toBe("test-chat");
+    expect(message).toContain("Morning.");
+    expect(message).toContain("3 Do First");
+    expect(message).toContain("LinkedIn outreach");
+  });
+
+  it("sends nightly recap with completion info", async () => {
+    const partialContent = readFileSync(path.join(fixturesDir, "runlist-partial.md"), "utf-8");
+    const bus = createMockBus();
+    const responder = createRunlistResponder({
+      vaultPath: "/vault",
+      telegramChatId: "test-chat",
+      fileReader: createMockFileReader({
+        "/vault/Runlist/2026-03-13.md": partialContent,
+      }),
+      clock: createMockClock("2026-03-13"),
+    });
+
+    responder.register(bus as any);
+
+    await bus.fire("cadence.cron.fired", {
+      jobId: "runlist-nightly",
+      jobName: "Runlist Nightly Recap",
+      expr: "0 22 * * *",
+      firedAt: Date.now(),
+    });
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    const [, message] = sendMock.mock.calls[0];
+    expect(message).toContain("Nightly.");
+    expect(message).toContain("done.");
+    expect(message).toContain("Unchecked:");
+  });
+
+  it("emits runlist.morning.sent signal after sending", async () => {
+    const fullContent = readFileSync(path.join(fixturesDir, "runlist-full.md"), "utf-8");
+    const bus = createMockBus();
+    const responder = createRunlistResponder({
+      vaultPath: "/vault",
+      telegramChatId: "test-chat",
+      fileReader: createMockFileReader({
+        "/vault/Runlist/2026-03-13.md": fullContent,
+      }),
+      clock: createMockClock("2026-03-13"),
+    });
+
+    responder.register(bus as any);
+
+    await bus.fire("cadence.cron.fired", {
+      jobId: "runlist-morning",
+      jobName: "Runlist Morning Ping",
+      expr: "30 7 * * *",
+      firedAt: Date.now(),
+    });
+
+    expect(bus.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "runlist.morning.sent",
+        payload: expect.objectContaining({
+          date: "2026-03-13",
+          focus: "Money",
+        }),
+      }),
+    );
+  });
+
+  it("returns unsubscribe function", () => {
+    const bus = createMockBus();
+    const responder = createRunlistResponder({
+      vaultPath: "/vault",
+      telegramChatId: "123",
+    });
+
+    const unsub = responder.register(bus as any);
+    expect(typeof unsub).toBe("function");
+  });
+});

--- a/src/cadence/responders/runlist/test/parser.test.ts
+++ b/src/cadence/responders/runlist/test/parser.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parseRunletSummary, parseTaskCompletion, findForcedDecisions } from "../parser.js";
+
+const fixturesDir = path.join(import.meta.dirname, "fixtures");
+
+function readFixture(name: string): string {
+  return readFileSync(path.join(fixturesDir, name), "utf-8");
+}
+
+describe("parseRunletSummary", () => {
+  it("extracts RUNLET_SUMMARY JSON from full runlist", () => {
+    const content = readFixture("runlist-full.md");
+    const summary = parseRunletSummary(content);
+
+    expect(summary).not.toBeNull();
+    expect(summary!.date).toBe("2026-03-13");
+    expect(summary!.focus).toBe("Money");
+    expect(summary!.counts.do_first).toBe(3);
+    expect(summary!.counts.block_time).toBe(2);
+    expect(summary!.counts.batch).toBe(2);
+    expect(summary!.counts.kill).toBe(2);
+    expect(summary!.top_task).toBe("LinkedIn outreach: 5 new conversations");
+    expect(summary!.tasks).toHaveLength(9);
+  });
+
+  it("returns null when no RUNLET_SUMMARY exists", () => {
+    const content = readFixture("runlist-no-summary.md");
+    const summary = parseRunletSummary(content);
+    expect(summary).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    const content = "<!-- RUNLET_SUMMARY\n{invalid json}\n-->";
+    expect(parseRunletSummary(content)).toBeNull();
+  });
+
+  it("parses carried items", () => {
+    const content = readFixture("runlist-3-carry.md");
+    const summary = parseRunletSummary(content);
+
+    expect(summary!.carried).toEqual(["Atlanta meetup search"]);
+    expect(summary!.carried_count).toBe(1);
+  });
+});
+
+describe("parseTaskCompletion", () => {
+  it("counts all tasks as pending in fresh runlist", () => {
+    const content = readFixture("runlist-full.md");
+    const completion = parseTaskCompletion(content);
+
+    expect(completion.done).toHaveLength(0);
+    expect(completion.pending).toHaveLength(7); // 3 do first + 2 block time + 2 batch
+  });
+
+  it("correctly splits done and pending", () => {
+    const content = readFixture("runlist-partial.md");
+    const completion = parseTaskCompletion(content);
+
+    expect(completion.done).toHaveLength(4); // LinkedIn, Reply, Discord, Dev.to
+    expect(completion.pending).toHaveLength(3); // Follow up, Atlanta, LinWheel
+  });
+
+  it("skips entry point lines", () => {
+    const content = readFixture("runlist-full.md");
+    const completion = parseTaskCompletion(content);
+
+    const allTasks = [...completion.done, ...completion.pending];
+    const entryPoints = allTasks.filter((t) => t.includes("Entry point"));
+    expect(entryPoints).toHaveLength(0);
+  });
+
+  it("skips killed (strikethrough) items", () => {
+    const content = readFixture("runlist-full.md");
+    const completion = parseTaskCompletion(content);
+
+    const allTasks = [...completion.done, ...completion.pending];
+    const killed = allTasks.filter((t) => t.includes("Rhythm") || t.includes("carousel"));
+    expect(killed).toHaveLength(0);
+  });
+});
+
+describe("findForcedDecisions", () => {
+  it("finds tasks in kill quadrant with carried_from", () => {
+    const content = readFixture("runlist-3-carry.md");
+    const summary = parseRunletSummary(content)!;
+    const forced = findForcedDecisions(summary.tasks);
+
+    expect(forced).toHaveLength(1);
+    expect(forced[0].description).toBe("Atlanta meetup search");
+    expect(forced[0].carried_from).toBe("2026-03-13");
+  });
+
+  it("returns empty for fresh runlist with no carries", () => {
+    const content = readFixture("runlist-full.md");
+    const summary = parseRunletSummary(content)!;
+    const forced = findForcedDecisions(summary.tasks);
+
+    expect(forced).toHaveLength(0);
+  });
+});

--- a/src/cadence/responders/runlist/types.ts
+++ b/src/cadence/responders/runlist/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Runlist responder types.
+ *
+ * Domain types for parsing RUNLET_SUMMARY JSON blocks
+ * from Obsidian vault runlist files.
+ */
+
+export interface RunletSummary {
+  date: string;
+  focus: string;
+  known_focuses: string[];
+  counts: {
+    do_first: number;
+    block_time: number;
+    batch: number;
+    kill: number;
+  };
+  top_task: string;
+  carried: string[];
+  carried_count: number;
+  tasks: RunletTask[];
+}
+
+export interface RunletTask {
+  description: string;
+  quadrant: "do_first" | "block_time" | "batch" | "kill";
+  energy: "low" | "high";
+  moves_focus: boolean;
+  focuses: string[];
+  carried_from: string | null;
+}
+
+export interface TaskCompletion {
+  done: string[];
+  pending: string[];
+}
+
+export interface RunlistResponderConfig {
+  /** Cron job IDs this responder listens for */
+  cronTriggerJobIds: string[];
+  /** Directory within vault containing runlist files (default: "Runlist") */
+  runlistDir: string;
+}

--- a/src/cadence/signals.ts
+++ b/src/cadence/signals.ts
@@ -147,6 +147,32 @@ export type OpenClawPayloadMap = {
     firedAt: number;
     tz?: string;
   };
+
+  /** GitHub scan completed (observability) */
+  "github.scan.completed": {
+    scanDate: string;
+    reposScanned: number;
+    reposWithActivity: number;
+    reposWithBuildlog: number;
+    repos: Array<{
+      name: string;
+      fullName: string;
+      mergedPRs: Array<{ number: number; title: string; url: string }>;
+      openPRs: Array<{ number: number; title: string; url: string }>;
+      buildlogEntries: Array<{ name: string; content: string }>;
+    }>;
+    errors: Array<{ repo: string; error: string }>;
+  };
+
+  /** GitHub synthesis written to vault */
+  "github.synthesis.written": {
+    outputPath: string;
+    scanDate: string;
+    reposIncluded: number;
+    totalPRs: number;
+    linkedinReady: boolean;
+    error?: string;
+  };
 };
 
 /**

--- a/src/cadence/signals.ts
+++ b/src/cadence/signals.ts
@@ -173,6 +173,27 @@ export type OpenClawPayloadMap = {
     linkedinReady: boolean;
     error?: string;
   };
+
+  /** Runlist morning ping sent via Telegram */
+  "runlist.morning.sent": {
+    date: string;
+    focus: string;
+    counts: {
+      do_first: number;
+      block_time: number;
+      batch: number;
+      kill: number;
+    };
+    carried_count: number;
+  };
+
+  /** Runlist nightly recap sent via Telegram */
+  "runlist.nightly.sent": {
+    date: string;
+    completed: number;
+    pending: number;
+    forcedDecisions: string[];
+  };
 };
 
 /**

--- a/src/gateway/server-cadence.ts
+++ b/src/gateway/server-cadence.ts
@@ -23,6 +23,7 @@ import {
   createTelegramNotifierResponder,
   createLinWheelPublisherResponder,
   createGitHubWatcherResponder,
+  createRunlistResponder,
   createOpenClawLLMAdapter,
   registerResponders,
   type Responder,
@@ -184,6 +185,20 @@ async function setupP1ContentPipeline(log: SubsystemLogger): Promise<P1PipelineR
     log.info("cadence: P1 GitHub watcher enabled (nightly scan → synthesis)");
   } else {
     log.debug("cadence: P1 GitHub watcher skipped (not enabled)");
+  }
+
+  // Runlist Responder (morning ping + nightly recap)
+  if (p1Config.runlist?.enabled && p1Config.delivery.telegramChatId) {
+    responders.push(
+      createRunlistResponder({
+        vaultPath: p1Config.vaultPath,
+        telegramChatId: p1Config.delivery.telegramChatId,
+        runlistDir: p1Config.runlist.runlistDir,
+      }),
+    );
+    log.info("cadence: P1 Runlist responder enabled (morning + nightly)");
+  } else if (p1Config.runlist?.enabled) {
+    log.warn("cadence: P1 Runlist enabled but no telegramChatId configured");
   }
 
   // Cron Bridge (for scheduled digests + github watcher)


### PR DESCRIPTION
## Summary

- Cron-triggered responder: reads RUNLET_SUMMARY JSON from Obsidian vault runlist files, sends Telegram pings
- 7:30 AM morning ping: task counts, top task, carried items
- 10:00 PM nightly recap: completion rate, unchecked items, 3-carry forced decisions
- No LLM — pure file read, parse, format, send

## What's included

- src/cadence/responders/runlist/ — 4 source files (index, parser, formatter, types)
- 3 test files, 4 fixtures, 25 tests all passing
- Signal types: runlist.morning.sent, runlist.nightly.sent
- Config: runlist.enabled, morningTime, nightlyTime, runlistDir
- Gateway wiring in server-cadence.ts
- All 391 existing tests still pass

Closes #102