### PR TITLE
fix(config): add cadence to Zod schema + barrel export

### DIFF
--- a/src/cadence/index.ts
+++ b/src/cadence/index.ts
@@ -46,6 +46,10 @@ export {
   createGitHubWatcherResponder,
   type GitHubWatcherOptions,
 } from "./responders/github-watcher/index.js";
+export {
+  createRunlistResponder,
+  type RunlistResponderOptions,
+} from "./responders/runlist/index.js";
 
 // LLM
 export { createOpenClawLLMAdapter, createMockLLMProvider } from "./llm/openclaw-adapter.js";

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -303,6 +303,20 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    cadence: z
+      .object({
+        enabled: z.boolean().optional(),
+        timezone: z.string().optional(),
+        vaultPath: z.string().optional(),
+        dailyNotePath: z.string().optional(),
+        channel: z.string().optional(),
+        to: z.string().optional(),
+        maxNudgesPerBlock: z.number().int().positive().optional(),
+        nudgeBackoff: z.string().optional(),
+        blocks: z.array(z.record(z.string(), z.unknown())).optional(),
+      })
+      .strict()
+      .optional(),
     learning: LearningSchema,
     green: GreenSchema,
     gateway: z


### PR DESCRIPTION
## Summary
- Add missing `cadence` key to `OpenClawSchema` Zod validation — the TypeScript type had it but the Zod schema rejected it as unrecognized
- Add missing barrel re-export for `createRunlistResponder` from `cadence/index.ts` (caused TS2305 build failure)

## Test plan
- [x] `pnpm build` passes
- [x] Gateway starts with `cadence` in `openclaw.json` (verified in sandbox VM)
- [x] Cadence signal bus initializes with runlist responder

🤖 Generated with [Claude Code](https://claude.com/claude-code)